### PR TITLE
feat: Implement basic Python frontend for hipStateVec

### DIFF
--- a/examples/run_simple_circuit.py
+++ b/examples/run_simple_circuit.py
@@ -1,0 +1,121 @@
+import sys
+import os
+import numpy as np
+
+# Add the python module to the path if it's not installed
+# This assumes the script is run from the root of the repository
+# and the compiled module is in build/python/rocq or similar
+module_paths = [
+    os.path.join(os.path.dirname(__file__), '..', 'build/python/rocq'),
+    os.path.join(os.path.dirname(__file__), '..', 'python'), # If __init__.py is in python/rocq
+]
+# Adjust based on your actual build output directory structure for the .so file
+# For development, people often build in a 'build' dir and run examples from root.
+# This path adjustment tries to find the module if it's in a typical build layout.
+
+# Try to find the local build if not installed
+# This is a common pattern for running examples before installation.
+# It assumes a certain build directory structure.
+# If you install the package, you can just do `import rocq`
+try:
+    import rocq
+except ImportError:
+    for path_to_try in module_paths:
+        if os.path.exists(os.path.join(path_to_try, 'rocq')): # Check if rocq package dir exists
+             print(f"Adding {path_to_try} to sys.path")
+             sys.path.insert(0, os.path.abspath(path_to_try))
+             break
+    try:
+        import rocq
+    except ImportError as e:
+        print("Failed to import rocq. Ensure the module is built and in PYTHONPATH,")
+        print("or run this script from the repository root after building.")
+        print(f"Original error: {e}")
+        sys.exit(1)
+
+
+def main():
+    print("Starting rocQuantum simple circuit example...")
+
+    try:
+        # 1. Create a Simulator instance
+        print("Initializing simulator...")
+        sim = rocq.Simulator()
+        print("Simulator initialized.")
+
+        # 2. Create a Circuit instance
+        num_qubits = 3
+        print(f"Creating a circuit with {num_qubits} qubits...")
+        circuit = rocq.Circuit(num_qubits=num_qubits, simulator=sim)
+        print("Circuit created.")
+
+        # 3. Apply some gates
+        print("Applying gates...")
+        circuit.h(0)
+        print("- Applied H to qubit 0")
+        circuit.cx(0, 1)
+        print("- Applied CX to control=0, target=1 (CNOT)")
+        circuit.rz(np.pi / 4, 2) # Apply Rz(pi/4) to qubit 2
+        print(f"- Applied Rz(pi/4) to qubit 2")
+
+        # Example of applying a generic 2-qubit unitary (SWAP matrix)
+        # SWAP = [[1,0,0,0], [0,0,1,0], [0,1,0,0], [0,0,0,1]]
+        swap_matrix = np.array([
+            [1, 0, 0, 0],
+            [0, 0, 1, 0],
+            [0, 1, 0, 0],
+            [0, 0, 0, 1]
+        ], dtype=np.complex64)
+        
+        print("Applying generic SWAP matrix to qubits 1 and 2...")
+        # The apply_unitary expects a DeviceBuffer.
+        # The Circuit class's apply_unitary will handle creating it.
+        circuit.apply_unitary(qubit_indices=[1, 2], matrix=swap_matrix)
+        print("- Generic SWAP matrix applied.")
+
+
+        # 4. Perform measurements
+        print("Performing measurements...")
+        
+        # Measure qubit 0
+        q0_outcome, q0_prob = circuit.measure(0)
+        print(f"- Measured qubit 0: outcome = {q0_outcome}, probability = {q0_prob:.4f}")
+        
+        # Note: State is collapsed after measurement. 
+        # If you want to measure another qubit on the *original* state, 
+        # you'd need to recreate the circuit or manage state copies.
+        # For this example, we continue with the collapsed state.
+
+        # Measure qubit 1 (on the state collapsed by measuring qubit 0)
+        # To get meaningful probabilities for qubit 1 independent of qubit 0's collapse,
+        # one would typically run the circuit again or use a non-destructive measurement method
+        # if the backend supported it (e.g. getting full probability vector).
+        # The current `measure` is destructive.
+        
+        # Let's re-initialize and apply a simple state for a clearer second measurement
+        print("Re-initializing circuit for another measurement example...")
+        circuit2 = rocq.Circuit(num_qubits=2, simulator=sim)
+        circuit2.h(0)
+        # Now measure qubit 0 of circuit2
+        q0_c2_outcome, q0_c2_prob = circuit2.measure(0)
+        print(f"- Circuit 2: Measured qubit 0: outcome = {q0_c2_outcome}, probability = {q0_c2_prob:.4f}")
+        # Measure qubit 1 of circuit2 (state is now collapsed based on q0_c2_outcome)
+        q1_c2_outcome, q1_c2_prob = circuit2.measure(1)
+        print(f"- Circuit 2: Measured qubit 1 (after q0 collapse): outcome = {q1_c2_outcome}, probability = {q1_c2_prob:.4f}")
+
+
+        print("\nTo get full state probabilities (not implemented in this example directly via a single call):")
+        print("One would typically use a dedicated function in hipStateVec to get the full state vector")
+        print("or probabilities, or sample multiple shots from the final state without intermediate collapse.")
+        print("The current 'measure' method is destructive.")
+
+
+    except RuntimeError as e:
+        print(f"An error occurred: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+    print("\nSimple circuit example finished.")
+
+if __name__ == "__main__":
+    main()

--- a/python/rocq/CMakeLists.txt
+++ b/python/rocq/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.18) # Pybind11 typically needs a modern CMake
+
+# Find Pybind11
+# This assumes Pybind11 is installed in a way CMake can find it (e.g., via pip install pybind11, or from source build)
+# Or, if using Pybind11 as a submodule:
+# add_subdirectory(${PROJECT_SOURCE_DIR}/extern/pybind11) # Adjust path if needed
+find_package(pybind11 REQUIRED)
+
+# Define the Python extension module
+# The name given here will be the name of the .so file (e.g., _rocq_hip_backend.cpython-38-x86_64-linux-gnu.so)
+# and can be imported in Python as `import _rocq_hip_backend` (or whatever name is chosen)
+pybind11_add_module(_rocq_hip_backend # Module name
+    SHARED # Create a shared library
+    bindings.cpp # Source file for the bindings
+)
+
+# Link against the hipStateVec library
+# Assumes hipStateVec is a target defined in a parent CMake scope (e.g., in src/hipStateVec/CMakeLists.txt)
+# and that the root CMakeLists.txt has `add_subdirectory(src/hipStateVec)` before `add_subdirectory(python/rocq)`
+target_link_libraries(_rocq_hip_backend PRIVATE hipStateVec)
+
+# Add include directories
+# Include directory for hipStateVec API (hipStateVec.h)
+target_include_directories(_rocq_hip_backend PRIVATE
+    ${PROJECT_SOURCE_DIR}/include # For rocquantum/hipStateVec.h
+    # Pybind11 include directory is usually handled by pybind11_add_module or find_package(pybind11)
+    # ${pybind11_INCLUDE_DIRS} # Explicitly if needed
+)
+
+# Optional: Specify C++ standard if not inherited or if specific version needed for bindings
+# target_compile_features(_rocq_hip_backend PRIVATE cxx_std_17) # Example for C++17
+
+# Optional: Installation rules for the Python module
+# This helps if you want to install your package system-wide or in a virtual environment
+# pybind11_install(_rocq_hip_backend) # Simplified install
+# Or more detailed:
+# install(TARGETS _rocq_hip_backend LIBRARY DESTINATION rocq) # Installs to <prefix>/lib/pythonX.Y/site-packages/rocq/
+# The destination should match the package structure you want.
+# For now, we'll rely on the build directory for testing.
+
+message(STATUS "rocQuantum Python bindings module configured: _rocq_hip_backend")

--- a/python/rocq/__init__.py
+++ b/python/rocq/__init__.py
@@ -1,0 +1,14 @@
+# __init__.py for the rocq package
+
+# Import the main classes from api.py to make them available
+# when the user does `import rocq`
+from .api import Simulator, Circuit
+
+# You can also define __all__ to specify what `from rocq import *` imports
+__all__ = ['Simulator', 'Circuit']
+
+# Optionally, you could also try to import the backend here and
+# expose some of its elements, or perform version checks, etc.
+# For now, just exposing the API classes is sufficient.
+
+# print("rocq package initialized") # For debug

--- a/python/rocq/api.py
+++ b/python/rocq/api.py
@@ -1,0 +1,253 @@
+import numpy as np
+from . import _rocq_hip_backend as backend # Assuming the compiled module is named this
+
+class Simulator:
+    """
+    Manages the hipStateVec simulation backend handle.
+    A Simulator instance is required to create and run circuits.
+    """
+    def __init__(self):
+        try:
+            self._handle_wrapper = backend.RocsvHandle()
+            self._active_circuits = 0 # Basic tracking of active circuits using this sim
+        except RuntimeError as e:
+            print(f"Failed to initialize rocQuantum Simulator: {e}")
+            print("Please ensure the ROCm environment is set up correctly and the rocQuantum backend libraries are found.")
+            raise
+
+    @property
+    def handle(self):
+        if self._handle_wrapper is None:
+            raise RuntimeError("Simulator handle is not initialized or has been released.")
+        return self._handle_wrapper # Corrected: self._handle_wrapper
+
+    # In a more complex scenario, if the handle could be explicitly released:
+    # def release(self):
+    #     if self._handle_wrapper:
+    #         # The C++ RocsvHandleWrapper destructor handles rocsvDestroy
+    #         self._handle_wrapper = None 
+    #         print("rocQuantum Simulator handle released.")
+
+    def __del__(self):
+        # The C++ RocsvHandleWrapper's destructor will be called automatically
+        # when the _handle_wrapper object is garbage collected if not explicitly released.
+        # print("Simulator instance being deleted.") # For debug
+        pass
+
+    def create_device_matrix(self, numpy_matrix: np.ndarray) -> backend.DeviceBuffer:
+        """
+        Creates a device buffer and copies a NumPy matrix to it.
+        The matrix should be of type np.complex64.
+        """
+        if not isinstance(numpy_matrix, np.ndarray):
+            raise TypeError("Input matrix must be a NumPy array.")
+        
+        # Ensure the numpy array is of type rocComplex (complex64) and C-contiguous
+        # Pybind11's array_t<rocComplex, py::array::c_style | py::array::forcecast> handles casting.
+        # However, it's good practice to ensure dtype.
+        if numpy_matrix.dtype != np.complex64:
+            # print("Warning: Input matrix dtype is not np.complex64. Attempting to cast.") # Optional warning
+            numpy_matrix = numpy_matrix.astype(np.complex64, order='C') # order='C' for c_style
+
+        if not numpy_matrix.flags['C_CONTIGUOUS']:
+            # print("Warning: Input matrix is not C-contiguous. Making a contiguous copy.") # Optional warning
+            numpy_matrix = np.ascontiguousarray(numpy_matrix, dtype=np.complex64)
+
+        return backend.create_device_matrix_from_numpy(numpy_matrix)
+
+
+class Circuit:
+    """
+    Represents a quantum circuit and provides methods to build and simulate it
+    using the hipStateVec backend.
+    """
+    def __init__(self, num_qubits: int, simulator: Simulator):
+        if not isinstance(simulator, Simulator):
+            raise TypeError("A valid Simulator instance is required.")
+        if num_qubits <= 0:
+            raise ValueError("Number of qubits must be positive.")
+
+        self.num_qubits = num_qubits
+        self.simulator = simulator
+        self._sim_handle = simulator._handle_wrapper # Get the C++ handle wrapper
+
+        try:
+            # allocate_state_internal returns an owning DeviceBuffer
+            self._d_state_buffer = backend.allocate_state_internal(self._sim_handle, self.num_qubits)
+            status = backend.initialize_state(self._sim_handle, self._d_state_buffer, self.num_qubits)
+            if status != backend.rocqStatus.SUCCESS:
+                raise RuntimeError(f"Failed to initialize state: {status}")
+            self.simulator._active_circuits +=1
+        except RuntimeError as e:
+            # If d_state_buffer was allocated but initialize failed, it will be auto-freed by DeviceBuffer destructor
+            # if self._d_state_buffer was assigned.
+            print(f"Error during Circuit initialization: {e}")
+            raise
+            
+    def __del__(self):
+        # The self._d_state_buffer (DeviceBuffer) will automatically call hipFree 
+        # in its C++ destructor when this Circuit object is garbage collected.
+        if hasattr(self, 'simulator') and self.simulator is not None and hasattr(self.simulator, '_active_circuits'):
+             self.simulator._active_circuits -=1
+        # print(f"Circuit for {self.num_qubits} qubits being deleted.") # For debug
+
+    def _validate_qubit_index(self, qubit_index, name="target qubit"):
+        if not isinstance(qubit_index, int) or not (0 <= qubit_index < self.num_qubits):
+            raise ValueError(
+                f"{name} index {qubit_index} is out of range for {self.num_qubits} qubits."
+            )
+
+    def _validate_control_target(self, control_qubit, target_qubit):
+        self._validate_qubit_index(control_qubit, "control qubit")
+        self._validate_qubit_index(target_qubit, "target qubit")
+        if control_qubit == target_qubit:
+            raise ValueError("Control and target qubits cannot be the same.")
+
+    # --- Single-Qubit Gates ---
+    def x(self, target_qubit: int):
+        self._validate_qubit_index(target_qubit)
+        status = backend.apply_x(self._sim_handle, self._d_state_buffer, self.num_qubits, target_qubit)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply X failed: {status}")
+
+    def y(self, target_qubit: int):
+        self._validate_qubit_index(target_qubit)
+        status = backend.apply_y(self._sim_handle, self._d_state_buffer, self.num_qubits, target_qubit)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply Y failed: {status}")
+
+    def z(self, target_qubit: int):
+        self._validate_qubit_index(target_qubit)
+        status = backend.apply_z(self._sim_handle, self._d_state_buffer, self.num_qubits, target_qubit)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply Z failed: {status}")
+
+    def h(self, target_qubit: int):
+        self._validate_qubit_index(target_qubit)
+        status = backend.apply_h(self._sim_handle, self._d_state_buffer, self.num_qubits, target_qubit)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply H failed: {status}")
+
+    def s(self, target_qubit: int):
+        self._validate_qubit_index(target_qubit)
+        status = backend.apply_s(self._sim_handle, self._d_state_buffer, self.num_qubits, target_qubit)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply S failed: {status}")
+
+    def t(self, target_qubit: int):
+        self._validate_qubit_index(target_qubit)
+        status = backend.apply_t(self._sim_handle, self._d_state_buffer, self.num_qubits, target_qubit)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply T failed: {status}")
+
+    def rx(self, angle: float, target_qubit: int):
+        self._validate_qubit_index(target_qubit)
+        status = backend.apply_rx(self._sim_handle, self._d_state_buffer, self.num_qubits, target_qubit, angle)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply Rx failed: {status}")
+
+    def ry(self, angle: float, target_qubit: int):
+        self._validate_qubit_index(target_qubit)
+        status = backend.apply_ry(self._sim_handle, self._d_state_buffer, self.num_qubits, target_qubit, angle)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply Ry failed: {status}")
+
+    def rz(self, angle: float, target_qubit: int):
+        self._validate_qubit_index(target_qubit)
+        status = backend.apply_rz(self._sim_handle, self._d_state_buffer, self.num_qubits, target_qubit, angle)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply Rz failed: {status}")
+
+    # --- Two-Qubit Gates ---
+    def cx(self, control_qubit: int, target_qubit: int): # CNOT
+        self._validate_control_target(control_qubit, target_qubit)
+        status = backend.apply_cnot(self._sim_handle, self._d_state_buffer, self.num_qubits, control_qubit, target_qubit)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply CNOT failed: {status}")
+
+    def cz(self, qubit1: int, qubit2: int):
+        self._validate_control_target(qubit1, qubit2) # Same validation applies
+        status = backend.apply_cz(self._sim_handle, self._d_state_buffer, self.num_qubits, qubit1, qubit2)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply CZ failed: {status}")
+
+    def swap(self, qubit1: int, qubit2: int):
+        self._validate_control_target(qubit1, qubit2) # Same validation applies
+        status = backend.apply_swap(self._sim_handle, self._d_state_buffer, self.num_qubits, qubit1, qubit2)
+        if status != backend.rocqStatus.SUCCESS: raise RuntimeError(f"Apply SWAP failed: {status}")
+
+    # --- Generic Unitary ---
+    def apply_unitary(self, qubit_indices: list[int], matrix: np.ndarray):
+        """
+        Applies a generic unitary matrix to the specified qubits.
+        
+        Args:
+            qubit_indices (list[int]): A list of target qubit indices.
+            matrix (np.ndarray): A NumPy array representing the unitary matrix.
+                                 Shape must be (2^m, 2^m) where m = len(qubit_indices).
+                                 dtype should be np.complex64.
+        """
+        num_target_qubits = len(qubit_indices)
+        if num_target_qubits == 0:
+            raise ValueError("qubit_indices cannot be empty for apply_unitary.")
+        for idx in qubit_indices:
+            self._validate_qubit_index(idx, f"qubit_indices element {idx}")
+        # Check for duplicate qubit indices
+        if len(set(qubit_indices)) != num_target_qubits:
+            raise ValueError("Duplicate qubit indices are not allowed.")
+
+        expected_dim = 1 << num_target_qubits
+        if matrix.shape != (expected_dim, expected_dim):
+            raise ValueError(
+                f"Matrix shape {matrix.shape} is not valid for {num_target_qubits} qubits. "
+                f"Expected ({expected_dim}, {expected_dim})."
+            )
+
+        # Python side creates a device matrix using the Simulator's helper
+        device_matrix_buffer = self.simulator.create_device_matrix(matrix)
+        
+        try:
+            status = backend.apply_matrix(
+                self._sim_handle, 
+                self._d_state_buffer, 
+                self.num_qubits,
+                qubit_indices,          # Pybind11 should handle list[int] to std::vector<unsigned>
+                device_matrix_buffer,   # Pass the DeviceBuffer object
+                expected_dim
+            )
+            if status != backend.rocqStatus.SUCCESS:
+                raise RuntimeError(f"Apply Matrix failed: {status}")
+        finally:
+            # device_matrix_buffer will be auto-freed by its C++ destructor
+            # when it goes out of scope in Python if it was created here.
+            # No explicit free needed if using the RAII DeviceBuffer from bindings.
+            pass
+
+
+    # --- Measurement ---
+    def measure(self, qubit_to_measure: int) -> tuple[int, float]:
+        """
+        Measures a single qubit in the computational basis.
+        This operation collapses the state vector.
+
+        Args:
+            qubit_to_measure (int): The index of the qubit to measure.
+
+        Returns:
+            tuple[int, float]: A tuple containing the measurement outcome (0 or 1)
+                               and the probability of that outcome.
+        """
+        self._validate_qubit_index(qubit_to_measure)
+        try:
+            outcome, probability = backend.measure(
+                self._sim_handle, self._d_state_buffer, self.num_qubits, qubit_to_measure
+            )
+            return outcome, probability
+        except RuntimeError as e:
+            raise RuntimeError(f"Measure failed: {e}")
+
+    # def get_probabilities(self): # Future enhancement
+    #     # This would ideally involve a hipStateVec function to copy probabilities or full state vector
+    #     # For now, users can call measure repeatedly (on copies or by re-preparing state)
+    #     # or use a future sampling function.
+    #     raise NotImplementedError("get_probabilities is not yet implemented.")
+
+    # def run(self, shots=1): # Future enhancement for shot-based simulation
+    #     # For now, operations are applied eagerly.
+    #     # This could collect measurement statistics over multiple shots.
+    #     if shots == 1: # For compatibility with a potential future API
+    #        print("Warning: 'run' method called with shots=1. Operations are applied eagerly. Consider using 'measure'.")
+    #        # Or, if a final measurement is implied:
+    #        # return self.measure_all() # if such a function exists
+    #     raise NotImplementedError("'run' method with shots is not fully implemented for this eager execution model.")
+
+```

--- a/python/rocq/bindings.cpp
+++ b/python/rocq/bindings.cpp
@@ -1,0 +1,276 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>       // For std::vector, std::map, etc.
+#include <pybind11/numpy.h>     // For py::array_t
+#include "rocquantum/hipStateVec.h" // Path to the C API header
+
+namespace py = pybind11;
+
+// Helper to convert py::array_t<rocComplex> (NumPy array from Python) to rocComplex* on device
+// This is a simplified helper. Error handling and memory management need care.
+// The caller is responsible for freeing d_matrix if it's allocated by this helper.
+// For rocsvApplyMatrix, matrixDevice is already on device, so this helper is for
+// a scenario where Python provides a host matrix that needs to be on device.
+// However, the rocsvApplyMatrix C-API now expects matrixDevice to *already* be on device.
+// So, the Python side will need to manage this (e.g. have a function to create device matrix from numpy).
+
+// Let's define a simple DeviceMemory class for Python to manage GPU buffers for matrices
+class DeviceBuffer {
+public:
+    void* ptr_ = nullptr;
+    size_t size_bytes_ = 0;
+    bool owned_ = true; // Does this wrapper own the memory (i.e., should it free it)?
+
+    DeviceBuffer() = default;
+
+    DeviceBuffer(size_t num_elements, size_t element_size) : size_bytes_(num_elements * element_size) {
+        if (hipMalloc(&ptr_, size_bytes_) != hipSuccess) {
+            throw std::runtime_error("Failed to allocate device memory in DeviceBuffer constructor");
+        }
+    }
+
+    // Constructor to wrap an existing device pointer (e.g., d_state)
+    // This wrapper does NOT own the memory.
+    DeviceBuffer(void* existing_ptr, size_t size_bytes, bool take_ownership = false) 
+        : ptr_(existing_ptr), size_bytes_(size_bytes), owned_(take_ownership) {}
+
+
+    ~DeviceBuffer() {
+        if (owned_ && ptr_) {
+            hipFree(ptr_);
+        }
+    }
+
+    // Disable copy constructor and assignment to prevent double free / shallow copies of owned memory
+    DeviceBuffer(const DeviceBuffer&) = delete;
+    DeviceBuffer& operator=(const DeviceBuffer&) = delete;
+
+    // Allow move construction and assignment
+    DeviceBuffer(DeviceBuffer&& other) noexcept : ptr_(other.ptr_), size_bytes_(other.size_bytes_), owned_(other.owned_) {
+        other.ptr_ = nullptr;
+        other.size_bytes_ = 0;
+        other.owned_ = false; // Transferred ownership
+    }
+
+    DeviceBuffer& operator=(DeviceBuffer&& other) noexcept {
+        if (this != &other) {
+            if (owned_ && ptr_) {
+                hipFree(ptr_);
+            }
+            ptr_ = other.ptr_;
+            size_bytes_ = other.size_bytes_;
+            owned_ = other.owned_;
+            other.ptr_ = nullptr;
+            other.size_bytes_ = 0;
+            other.owned_ = false;
+        }
+        return *this;
+    }
+
+    void copy_from_numpy(py::array_t<rocComplex, py::array::c_style | py::array::forcecast> np_array) {
+        if (!ptr_ || np_array.nbytes() > size_bytes_) {
+            throw std::runtime_error("Device buffer not allocated, null, or NumPy array too large.");
+        }
+        if (hipMemcpy(ptr_, np_array.data(), np_array.nbytes(), hipMemcpyHostToDevice) != hipSuccess) {
+            throw std::runtime_error("Failed to copy NumPy array to device");
+        }
+    }
+    
+    // Method to get the raw pointer (e.g., rocComplex*)
+    template<typename T>
+    T* get_ptr() const {
+        return static_cast<T*>(ptr_);
+    }
+    
+    size_t nbytes() const { return size_bytes_; }
+};
+
+
+// Wrapper for rocsvHandle_t to ensure proper creation and destruction
+class RocsvHandleWrapper {
+public:
+    rocsvHandle_t handle_ = nullptr;
+
+    RocsvHandleWrapper() {
+        rocqStatus_t status = rocsvCreate(&handle_);
+        if (status != ROCQ_STATUS_SUCCESS) {
+            throw std::runtime_error("Failed to create rocsvHandle: " + std::to_string(status));
+        }
+    }
+
+    ~RocsvHandleWrapper() {
+        if (handle_) {
+            rocsvDestroy(handle_); // Ignoring status on destroy for simplicity in destructor
+        }
+    }
+
+    // Disable copy constructor and assignment
+    RocsvHandleWrapper(const RocsvHandleWrapper&) = delete;
+    RocsvHandleWrapper& operator=(const RocsvHandleWrapper&) = delete;
+
+    // Allow move construction
+    RocsvHandleWrapper(RocsvHandleWrapper&& other) noexcept : handle_(other.handle_) {
+        other.handle_ = nullptr;
+    }
+    // Allow move assignment
+    RocsvHandleWrapper& operator=(RocsvHandleWrapper&& other) noexcept {
+        if (this != &other) {
+            if (handle_) {
+                rocsvDestroy(handle_);
+            }
+            handle_ = other.handle_;
+            other.handle_ = nullptr;
+        }
+        return *this;
+    }
+
+    rocsvHandle_t get() const { return handle_; }
+};
+
+
+PYBIND11_MODULE(_rocq_hip_backend, m) {
+    m.doc() = "Python bindings for rocQuantum hipStateVec library";
+
+    py::enum_<rocqStatus_t>(m, "rocqStatus")
+        .value("SUCCESS", ROCQ_STATUS_SUCCESS)
+        .value("FAILURE", ROCQ_STATUS_FAILURE)
+        .value("INVALID_VALUE", ROCQ_STATUS_INVALID_VALUE)
+        .value("ALLOCATION_FAILED", ROCQ_STATUS_ALLOCATION_FAILED)
+        .value("HIP_ERROR", ROCQ_STATUS_HIP_ERROR)
+        .value("NOT_IMPLEMENTED", ROCQ_STATUS_NOT_IMPLEMENTED)
+        .export_values();
+
+    // DeviceBuffer class for managing device memory from Python
+    py::class_<DeviceBuffer>(m, "DeviceBuffer")
+        .def(py::init<>()) // Default constructor
+        .def(py::init<size_t, size_t>(), py::arg("num_elements"), py::arg("element_size"))
+        .def("copy_from_numpy", &DeviceBuffer::copy_from_numpy, "Copies data from a NumPy array to the device buffer.")
+        .def("nbytes", &DeviceBuffer::nbytes, "Returns the size of the buffer in bytes.");
+        // get_ptr is not directly exposed as it's unsafe for general Python.
+        // Python code will pass DeviceBuffer objects to wrapped C functions that extract the pointer.
+
+
+    // Wrapper for the handle
+    py::class_<RocsvHandleWrapper>(m, "RocsvHandle")
+        .def(py::init<>());
+        // The handle itself is mostly opaque to Python users of this direct binding layer.
+        // Higher-level Python classes (Simulator) will use it.
+
+    // State management functions
+    // rocsvAllocateState: The returned d_state (rocComplex**) is tricky.
+    // We'll return a DeviceBuffer that wraps the allocated device pointer.
+    m.def("allocate_state_internal", 
+        [](const RocsvHandleWrapper& handle_wrapper, unsigned numQubits) {
+            rocComplex* d_state_ptr = nullptr;
+            rocqStatus_t status = rocsvAllocateState(handle_wrapper.get(), numQubits, &d_state_ptr);
+            if (status != ROCQ_STATUS_SUCCESS) {
+                throw std::runtime_error("rocsvAllocateState failed: " + std::to_string(status));
+            }
+            size_t num_elements = 1ULL << numQubits;
+            // The DeviceBuffer now owns this d_state_ptr and will hipFree it.
+            return DeviceBuffer(static_cast<void*>(d_state_ptr), num_elements * sizeof(rocComplex), true /*owned*/);
+        }, py::arg("handle"), py::arg("num_qubits"), "Allocates state vector on device, returns an owning DeviceBuffer.");
+
+    m.def("initialize_state", 
+        [](const RocsvHandleWrapper& handle_wrapper, DeviceBuffer& d_state_buffer, unsigned numQubits) {
+            // Basic check, Python side should ensure numQubits matches buffer allocation
+            if (d_state_buffer.nbytes() != ( (1ULL << numQubits) * sizeof(rocComplex) ) ) {
+                 throw std::runtime_error("DeviceBuffer size mismatch in initialize_state");
+            }
+            return rocsvInitializeState(handle_wrapper.get(), d_state_buffer.get_ptr<rocComplex>(), numQubits);
+        }, py::arg("handle"), py::arg("d_state_buffer"), py::arg("num_qubits"));
+
+    // Specific single-qubit gates
+    m.def("apply_x", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned tQ) {
+        return rocsvApplyX(h.get(), d_state.get_ptr<rocComplex>(), nQ, tQ); }, "Applies X gate");
+    m.def("apply_y", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned tQ) {
+        return rocsvApplyY(h.get(), d_state.get_ptr<rocComplex>(), nQ, tQ); }, "Applies Y gate");
+    m.def("apply_z", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned tQ) {
+        return rocsvApplyZ(h.get(), d_state.get_ptr<rocComplex>(), nQ, tQ); }, "Applies Z gate");
+    m.def("apply_h", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned tQ) {
+        return rocsvApplyH(h.get(), d_state.get_ptr<rocComplex>(), nQ, tQ); }, "Applies H gate");
+    m.def("apply_s", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned tQ) {
+        return rocsvApplyS(h.get(), d_state.get_ptr<rocComplex>(), nQ, tQ); }, "Applies S gate");
+    m.def("apply_t", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned tQ) {
+        return rocsvApplyT(h.get(), d_state.get_ptr<rocComplex>(), nQ, tQ); }, "Applies T gate");
+
+    // Rotation gates
+    m.def("apply_rx", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned tQ, double angle) {
+        return rocsvApplyRx(h.get(), d_state.get_ptr<rocComplex>(), nQ, tQ, angle); }, "Applies Rx gate");
+    m.def("apply_ry", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned tQ, double angle) {
+        return rocsvApplyRy(h.get(), d_state.get_ptr<rocComplex>(), nQ, tQ, angle); }, "Applies Ry gate");
+    m.def("apply_rz", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned tQ, double angle) {
+        return rocsvApplyRz(h.get(), d_state.get_ptr<rocComplex>(), nQ, tQ, angle); }, "Applies Rz gate");
+
+    // Specific two-qubit gates
+    m.def("apply_cnot", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned ctrlQ, unsigned tgtQ) {
+        return rocsvApplyCNOT(h.get(), d_state.get_ptr<rocComplex>(), nQ, ctrlQ, tgtQ); }, "Applies CNOT gate");
+    m.def("apply_cz", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned q1, unsigned q2) {
+        return rocsvApplyCZ(h.get(), d_state.get_ptr<rocComplex>(), nQ, q1, q2); }, "Applies CZ gate");
+    m.def("apply_swap", [](const RocsvHandleWrapper& h, DeviceBuffer& d_state, unsigned nQ, unsigned q1, unsigned q2) {
+        return rocsvApplySWAP(h.get(), d_state.get_ptr<rocComplex>(), nQ, q1, q2); }, "Applies SWAP gate");
+    
+    // rocsvApplyMatrix
+    m.def("apply_matrix", 
+        [](const RocsvHandleWrapper& handle_wrapper, 
+           DeviceBuffer& d_state_buffer, 
+           unsigned numQubits, 
+           std::vector<unsigned> qubitIndices_vec, // Use std::vector for easy conversion
+           DeviceBuffer& matrix_device_buffer, // Matrix already on device
+           unsigned matrixDim) {
+            // Basic checks
+            if (qubitIndices_vec.size() == 0) {
+                throw std::runtime_error("qubitIndices must not be empty for apply_matrix");
+            }
+            unsigned numTargetQubits = qubitIndices_vec.size();
+            // matrixDim should be 1U << numTargetQubits
+            // matrix_device_buffer.nbytes() should be matrixDim * matrixDim * sizeof(rocComplex)
+            
+            // The C API expects const unsigned* for qubitIndices.
+            // The d_targetIndices for m=3,4,>=5 in C++ code is created on device.
+            // Here, qubitIndices is passed from Python as a list/vector, used by C++ to create d_targetIndices.
+            // The current C API rocsvApplyMatrix takes const unsigned* qubitIndices (host pointer).
+            // This is consistent.
+
+            return rocsvApplyMatrix(handle_wrapper.get(), 
+                                    d_state_buffer.get_ptr<rocComplex>(), 
+                                    numQubits, 
+                                    qubitIndices_vec.data(), // Pass pointer to vector's data
+                                    numTargetQubits, 
+                                    matrix_device_buffer.get_ptr<rocComplex>(), 
+                                    matrixDim);
+        }, py::arg("handle"), py::arg("d_state"), py::arg("num_qubits"), 
+           py::arg("qubit_indices"), py::arg("matrix_device"), py::arg("matrix_dim"));
+
+    // rocsvMeasure
+    m.def("measure", 
+        [](const RocsvHandleWrapper& handle_wrapper, DeviceBuffer& d_state_buffer, unsigned numQubits, unsigned qubitToMeasure) {
+            int outcome = 0;
+            double probability = 0.0;
+            rocqStatus_t status = rocsvMeasure(handle_wrapper.get(), 
+                                               d_state_buffer.get_ptr<rocComplex>(), 
+                                               numQubits, 
+                                               qubitToMeasure, 
+                                               &outcome, &probability);
+            if (status != ROCQ_STATUS_SUCCESS) {
+                throw std::runtime_error("rocsvMeasure failed: " + std::to_string(status));
+            }
+            return py::make_tuple(outcome, probability);
+        }, py::arg("handle"), py::arg("d_state"), py::arg("num_qubits"), py::arg("qubit_to_measure"),
+           "Measures a single qubit. Returns (outcome, probability).");
+
+    // Add a helper to create a DeviceBuffer and copy a numpy array to it
+    m.def("create_device_matrix_from_numpy",
+        [](py::array_t<rocComplex, py::array::c_style | py::array::forcecast> np_array) {
+            if (np_array.ndim() != 2) throw std::runtime_error("NumPy array must be 2D for matrix.");
+            // For this simple version, assume square matrix.
+            // size_t rows = np_array.shape(0);
+            // size_t cols = np_array.shape(1);
+            // if (rows != cols) throw std::runtime_error("Matrix must be square.");
+            
+            size_t num_elements = np_array.size();
+            DeviceBuffer db(num_elements, sizeof(rocComplex));
+            db.copy_from_numpy(np_array);
+            return db;
+        }, py::arg("numpy_array"), "Creates a DeviceBuffer and copies a NumPy array to it.");
+
+}

--- a/rocquantum/CMakeLists.txt
+++ b/rocquantum/CMakeLists.txt
@@ -72,3 +72,5 @@ add_subdirectory(src/hipStateVec)
 # add_subdirectory(tests/hipStateVec) # If you add tests later
 
 message(STATUS "rocQuantum project configured. HIP compiler: ${CMAKE_HIP_COMPILER}")
+
+add_subdirectory(python/rocq)


### PR DESCRIPTION
This commit introduces the initial Python frontend for rocQuantum, allowing you to define and simulate quantum circuits using the hipStateVec backend.

Key components added:
- Python Bindings (`python/rocq/bindings.cpp`):
    - Uses Pybind11 to wrap the C-API of the hipStateVec library.
    - Includes helper C++ classes `DeviceBuffer` (for GPU memory management from Python) and `RocsvHandleWrapper` (for RAII of hipStateVec handles).
    - Exposes core hipStateVec functions: state management, specific gate applications (X, Y, Z, H, S, T, Rx, Ry, Rz, CNOT, CZ, SWAP), generic matrix application (`rocsvApplyMatrix`), and measurement (`rocsvMeasure`).
- Python API (`python/rocq/api.py`):
    - `Simulator` class: Manages the underlying `rocsvHandle_t`.
    - `Circuit` class:
        - Initializes and manages the quantum state vector on the device.
        - Provides user-friendly methods to apply quantum gates (e.g., `circuit.h(0)`, `circuit.cx(0,1)`). - Includes `apply_unitary()` method to apply custom matrices (passed as NumPy arrays). - Implements a `measure()` method for single-qubit measurements.
- CMake Integration:
    - Added `python/rocq/CMakeLists.txt` to build the Pybind11 bindings into a Python extension module (`_rocq_hip_backend`).
    - Updated the root `CMakeLists.txt` to include the Python subdirectory.
- Packaging:
    - Added `python/rocq/__init__.py` to structure `rocq` as a Python package and export the `Simulator` and `Circuit` classes.
- Example Usage (`examples/run_simple_circuit.py`):
    - A script demonstrating how to import `rocq`, create a simulator and circuit, apply gates, and perform measurements.

This provides a foundational end-to-end capability for you to interact with the rocQuantum simulation engine from Python.