### PR TITLE
feat: Implement hipTensorNet contraction logic and workspace manager

### DIFF
--- a/rocquantum/include/rocquantum/rocWorkspaceManager.h
+++ b/rocquantum/include/rocquantum/rocWorkspaceManager.h
@@ -1,0 +1,68 @@
+#ifndef ROC_WORKSPACE_MANAGER_H
+#define ROC_WORKSPACE_MANAGER_H
+
+#include "rocquantum/hipStateVec.h" // For rocComplex, rocqStatus_t
+#include <hip/hip_runtime.h>
+#include <cstddef> // For size_t
+#include <stdexcept> // For std::runtime_error
+
+namespace rocquantum {
+namespace util {
+
+class WorkspaceManager {
+public:
+    /**
+     * @brief Constructs a WorkspaceManager.
+     * @param initial_size_bytes The initial size of the workspace to allocate on the device.
+     * @param stream The HIP stream to associate with allocations if needed by underlying mechanisms
+     *               (though basic bump allocator might not use it directly for allocation itself).
+     *               Currently not used in this simple implementation.
+     */
+    WorkspaceManager(size_t initial_size_bytes, hipStream_t stream = 0);
+    ~WorkspaceManager();
+
+    // Disable copy constructor and assignment
+    WorkspaceManager(const WorkspaceManager&) = delete;
+    WorkspaceManager& operator=(const WorkspaceManager&) = delete;
+
+    /**
+     * @brief Allocates a block of memory from the workspace.
+     * Uses a simple bump allocation strategy.
+     * @param num_elements The number of rocComplex elements to allocate.
+     * @return Device pointer to the allocated memory, or nullptr if allocation fails or not enough space.
+     */
+    rocComplex* allocate(size_t num_elements);
+
+    /**
+     * @brief Resets the workspace, making all its memory available again.
+     * For the bump allocator, this simply resets the current offset.
+     */
+    void reset();
+
+    /**
+     * @brief Gets the total size of the workspace in bytes.
+     */
+    size_t get_total_size_bytes() const;
+
+    /**
+     * @brief Gets the currently used size of the workspace in bytes.
+     */
+    size_t get_used_size_bytes() const;
+
+    /**
+     * @brief Gets the underlying HIP stream (currently unused by allocator but stored).
+     */
+    hipStream_t get_stream() const;
+
+private:
+    rocComplex* d_workspace_ptr_ = nullptr;
+    size_t total_size_bytes_ = 0;
+    size_t current_offset_bytes_ = 0;
+    hipStream_t stream_ = 0; // Associated stream, for future use or if allocators need it
+    const size_t alignment_ = 256; // Common alignment, e.g., for texture memory or performance
+};
+
+} // namespace util
+} // namespace rocquantum
+
+#endif // ROC_WORKSPACE_MANAGER_H

--- a/rocquantum/src/hipTensorNet/hipTensorNet.cpp
+++ b/rocquantum/src/hipTensorNet/hipTensorNet.cpp
@@ -1,5 +1,6 @@
 #include "rocquantum/hipTensorNet.h"
 #include "rocquantum/hipStateVec.h" // For rocqStatus_t
+#include "rocquantum/rocWorkspaceManager.h" // For WorkspaceManager
 #include <vector>
 #include <new> // For std::nothrow
 #include <algorithm> // For std::sort, std::min, std::max
@@ -9,6 +10,7 @@
 // Define the opaque struct that rocTensorNetworkHandle_t points to
 struct rocTnStruct {
     rocquantum::TensorNetwork network;
+    // The network itself will own its workspace manager if created internally
 };
 
 extern "C" {
@@ -17,11 +19,25 @@ rocqStatus_t rocTensorNetworkCreate(rocTensorNetworkHandle_t* handle) {
     if (!handle) {
         return ROCQ_STATUS_INVALID_VALUE;
     }
-    rocTnStruct* tn_struct = new(std::nothrow) rocTnStruct();
-    if (!tn_struct) {
+    rocTnStruct* tn_struct = nullptr;
+    try {
+        // TensorNetwork constructor now creates a default WorkspaceManager
+        tn_struct = new rocTnStruct();
+    } catch (const std::bad_alloc& e) {
+        *handle = nullptr;
+        return ROCQ_STATUS_ALLOCATION_FAILED;
+    } catch (const std::runtime_error& e_ws) { // Catch workspace allocation failure
+        // std::cerr << "Error creating TensorNetwork: " << e_ws.what() << std::endl;
+        if (tn_struct) delete tn_struct; // Should not happen if constructor throws
+        *handle = nullptr;
+        return ROCQ_STATUS_ALLOCATION_FAILED; // Or a more specific workspace error
+    }
+
+    if (!tn_struct) { // Should be caught by bad_alloc, but as a safeguard
         *handle = nullptr;
         return ROCQ_STATUS_ALLOCATION_FAILED;
     }
+
     *handle = tn_struct;
     return ROCQ_STATUS_SUCCESS;
 }
@@ -31,15 +47,8 @@ rocqStatus_t rocTensorNetworkDestroy(rocTensorNetworkHandle_t handle) {
         return ROCQ_STATUS_INVALID_VALUE;
     }
     rocTnStruct* tn_struct = static_cast<rocTnStruct*>(handle);
-    // If TensorNetwork owns any tensors in active_tensors_during_contraction_
-    // (e.g. intermediates), they should be freed here.
-    for(auto& tensor : tn_struct->network.active_tensors_during_contraction_) {
-        if (tensor.owned_ && tensor.data_) {
-            rocquantum::util::rocTensorFree(&tensor);
-        }
-    }
-    tn_struct->network.active_tensors_during_contraction_.clear();
-    // initial_tensors_ are assumed to be views not owned by TensorNetwork itself.
+    // TensorNetwork destructor will handle freeing its owned workspace
+    // and any owned tensors in active_tensors_during_contraction_ (though they should be workspace managed)
     delete tn_struct;
     return ROCQ_STATUS_SUCCESS;
 }
@@ -56,7 +65,7 @@ rocqStatus_t rocTensorNetworkAddTensor(rocTensorNetworkHandle_t handle, const ro
     return ROCQ_STATUS_SUCCESS;
 }
 
-/* rocTensorNetworkAddContraction is removed as contractions are found dynamically.
+/* rocTensorNetworkAddContraction is removed
 rocqStatus_t rocTensorNetworkAddContraction(rocTensorNetworkHandle_t handle,
                                             int tensor_idx_A, int mode_idx_A,
                                             int tensor_idx_B, int mode_idx_B) {
@@ -78,29 +87,30 @@ rocqStatus_t rocTensorNetworkContract(rocTensorNetworkHandle_t handle,
 } // extern "C"
 
 
+// Implementation of TensorNetwork methods
 rocqStatus_t rocquantum::TensorNetwork::contract(
     rocquantum::util::rocTensor* result_tensor_out,
     rocblas_handle blas_handle,
     hipStream_t stream) {
 
     if (initial_tensors_.empty()) {
-        if (result_tensor_out) { // Should return a scalar 1 if network is empty? Or error?
-            result_tensor_out->dimensions_ = {1};
-            result_tensor_out->labels_ = {"scalar"};
-            result_tensor_out->calculate_strides();
-            // Caller should allocate if they expect a scalar. For now, error.
-        }
         return ROCQ_STATUS_INVALID_VALUE;
     }
 
-    // Clear previous active tensors and start with copies of initial tensors.
-    // Free any owned data from a previous partial contraction attempt.
-    for(auto& t : active_tensors_during_contraction_) {
-        rocquantum::util::rocTensorFree(&t);
+    for(auto& t : active_tensors_during_contraction_) { // Clear any owned from previous failed attempts
+        if (t.owned_) rocquantum::util::rocTensorFree(&t);
     }
     active_tensors_during_contraction_.clear();
     for(const auto& t_init : initial_tensors_){
-        active_tensors_during_contraction_.push_back(t_init); // These are views, owned_ = false
+        active_tensors_during_contraction_.push_back(t_init);
+    }
+
+    if (workspace_) {
+        workspace_->reset();
+    } else {
+        // Fallback: no workspace available, proceed with individual hipMalloc/hipFree
+        // This path should ideally emit a warning or be less preferred.
+        // std::cout << "Warning: Contracting tensor network without a workspace manager. Performance may be impacted." << std::endl;
     }
 
     while (active_tensors_during_contraction_.size() > 1) {
@@ -110,7 +120,6 @@ rocqStatus_t rocquantum::TensorNetwork::contract(
             for (size_t j = i + 1; j < active_tensors_during_contraction_.size(); ++j) {
                 const auto& t1 = active_tensors_during_contraction_[i];
                 const auto& t2 = active_tensors_during_contraction_[j];
-
                 std::vector<std::pair<int, int>> shared_modes = find_shared_mode_indices(t1, t2);
 
                 if (!shared_modes.empty()) {
@@ -118,24 +127,15 @@ rocqStatus_t rocquantum::TensorNetwork::contract(
                     cand.tensor_idx1 = static_cast<int>(i);
                     cand.tensor_idx2 = static_cast<int>(j);
                     cand.mode_pairs_to_contract = shared_modes;
-
                     std::vector<long long> res_dims;
                     std::vector<std::string> res_labels;
                     get_resulting_tensor_metadata(t1, t2, shared_modes, res_dims, res_labels);
-
                     cand.resulting_tensor_size = 1;
-                    if (res_dims.empty()){
-                        cand.resulting_tensor_size = 1;
-                    } else {
+                    if (res_dims.empty()){ cand.resulting_tensor_size = 1; }
+                    else {
                         for (long long dim : res_dims) {
-                            if (dim == 0) {
-                                cand.resulting_tensor_size = 0;
-                                break;
-                            }
-                            // Check for potential overflow before multiplication
-                            if (dim > 0 && cand.resulting_tensor_size > LLONG_MAX / dim) {
-                                return ROCQ_STATUS_INVALID_VALUE; // Overflow in size calculation
-                            }
+                            if (dim == 0) { cand.resulting_tensor_size = 0; break; }
+                            if (dim > 0 && cand.resulting_tensor_size > LLONG_MAX / dim) return ROCQ_STATUS_INVALID_VALUE;
                             cand.resulting_tensor_size *= dim;
                         }
                     }
@@ -145,20 +145,17 @@ rocqStatus_t rocquantum::TensorNetwork::contract(
         }
 
         if (candidates.empty()) {
-            if (active_tensors_during_contraction_.size() > 1) {
-                return ROCQ_STATUS_FAILURE; // Disconnected network
-            }
+            if (active_tensors_during_contraction_.size() > 1) return ROCQ_STATUS_FAILURE;
             break;
         }
 
         std::sort(candidates.begin(), candidates.end());
         const ContractionCandidate& best_candidate = candidates[0];
 
-        // These are views/copies from active_tensors_during_contraction_
         rocquantum::util::rocTensor tensor_A_view = active_tensors_during_contraction_[best_candidate.tensor_idx1];
         rocquantum::util::rocTensor tensor_B_view = active_tensors_during_contraction_[best_candidate.tensor_idx2];
 
-        rocquantum::util::rocTensor intermediate_result_tensor; // This will be the new tensor
+        rocquantum::util::rocTensor intermediate_result_tensor;
         std::vector<long long> new_dims;
         std::vector<std::string> new_labels;
         get_resulting_tensor_metadata(tensor_A_view, tensor_B_view, best_candidate.mode_pairs_to_contract, new_dims, new_labels);
@@ -166,26 +163,25 @@ rocqStatus_t rocquantum::TensorNetwork::contract(
         intermediate_result_tensor.dimensions_ = new_dims;
         intermediate_result_tensor.labels_ = new_labels;
         intermediate_result_tensor.calculate_strides();
-        // intermediate_result_tensor.owned_ will be set by rocTensorAllocate
 
-        // TODO FUTURE: Workspace Memory Management
-        // The allocation and deallocation of intermediate tensors here using
-        // rocTensorAllocate and rocTensorFree can be inefficient due to repeated
-        // hipMalloc/hipFree calls. A future optimization would be to implement
-        // a workspace memory manager.
-        // 1. A WorkspaceManager class would pre-allocate a large device memory pool.
-        // 2. rocTensorAllocate would be replaced by workspace_manager.allocate().
-        // 3. rocTensorFree for these intermediates would not call hipFree directly;
-        //    instead, the workspace would be reset after the full network contraction.
-        rocqStatus_t alloc_status = rocquantum::util::rocTensorAllocate(&intermediate_result_tensor);
-        if (alloc_status != ROCQ_STATUS_SUCCESS) {
-             // Clean up previously allocated intermediates if any error occurs.
-             for(auto& t : active_tensors_during_contraction_) {
-                if (t.owned_ && t.data_ != tensor_A_view.data_ && t.data_ != tensor_B_view.data_) { // Don't free inputs here
-                    rocquantum::util::rocTensorFree(&t);
-                }
-             }
-            return alloc_status;
+        if (workspace_) {
+            intermediate_result_tensor.data_ = workspace_->allocate(intermediate_result_tensor.get_element_count());
+            if (!intermediate_result_tensor.data_ && intermediate_result_tensor.get_element_count() > 0) {
+                for(auto& t : active_tensors_during_contraction_) if(t.owned_) rocquantum::util::rocTensorFree(&t);
+                return ROCQ_STATUS_ALLOCATION_FAILED; // Workspace full
+            }
+            intermediate_result_tensor.owned_ = false; // Workspace manages this memory block
+        } else {
+            rocqStatus_t alloc_status = rocquantum::util::rocTensorAllocate(&intermediate_result_tensor);
+            if (alloc_status != ROCQ_STATUS_SUCCESS) {
+                 for(auto& t : active_tensors_during_contraction_) {
+                    if (t.owned_ && t.data_ != tensor_A_view.data_ && t.data_ != tensor_B_view.data_) {
+                        rocquantum::util::rocTensorFree(&t);
+                    }
+                 }
+                return alloc_status;
+            }
+            // rocTensorAllocate sets owned_ = true
         }
 
         std::vector<int> result_A_modes_order;
@@ -210,12 +206,16 @@ rocqStatus_t rocquantum::TensorNetwork::contract(
         );
 
         if (contract_status != ROCQ_STATUS_SUCCESS) {
-            rocquantum::util::rocTensorFree(&intermediate_result_tensor);
-            for(auto& t : active_tensors_during_contraction_) rocquantum::util::rocTensorFree(&t);
+            // If allocated from workspace, memory is reclaimed on workspace_.reset().
+            // If allocated individually (owned_=true), free it.
+            if (intermediate_result_tensor.owned_ && intermediate_result_tensor.data_) {
+                 rocquantum::util::rocTensorFree(&intermediate_result_tensor);
+            }
+            // Free any other owned intermediates from active_tensors_
+            for(auto& t : active_tensors_during_contraction_) if(t.owned_) rocquantum::util::rocTensorFree(&t);
             return contract_status;
         }
 
-        // Update active_tensors_during_contraction_ list
         std::vector<rocquantum::util::rocTensor> next_active_tensors;
         int idx1 = best_candidate.tensor_idx1;
         int idx2 = best_candidate.tensor_idx2;
@@ -224,8 +224,11 @@ rocqStatus_t rocquantum::TensorNetwork::contract(
             if (k != static_cast<size_t>(idx1) && k != static_cast<size_t>(idx2)) {
                 next_active_tensors.push_back(std::move(active_tensors_during_contraction_[k]));
             } else {
-                // If the consumed tensor was an intermediate (owned its data), free it.
-                rocquantum::util::rocTensorFree(&active_tensors_during_contraction_[k]);
+                // If the consumed tensor was individually owned (not from workspace), free it.
+                if (active_tensors_during_contraction_[k].owned_) {
+                    rocquantum::util::rocTensorFree(&active_tensors_during_contraction_[k]);
+                }
+                // If it was from workspace, its memory will be reclaimed by workspace_->reset() later.
             }
         }
         next_active_tensors.push_back(std::move(intermediate_result_tensor));
@@ -233,67 +236,63 @@ rocqStatus_t rocquantum::TensorNetwork::contract(
     }
 
     if (active_tensors_during_contraction_.size() == 1) {
-        // Transfer data and ownership to result_tensor_out
-        // The caller of rocTensorNetworkContract is responsible for allocating result_tensor_out struct,
-        // but its data buffer should be allocated here if it's not already or if sizes mismatch.
+        rocquantum::util::rocTensor& final_computed_tensor = active_tensors_during_contraction_[0];
 
-        rocquantum::util::rocTensor& final_tensor = active_tensors_during_contraction_[0];
-
-        // If result_tensor_out is not pre-allocated or shape mismatch, reallocate
-        bool shape_match = result_tensor_out->dimensions_ == final_tensor.dimensions_;
-        if (!result_tensor_out->data_ || !shape_match || result_tensor_out->get_element_count() != final_tensor.get_element_count()) {
-            rocquantum::util::rocTensorFree(result_tensor_out); // Free if it owned different memory
-            result_tensor_out->dimensions_ = final_tensor.dimensions_;
-            result_tensor_out->labels_ = final_tensor.labels_; // Also copy labels
+        bool shape_match = result_tensor_out->dimensions_ == final_computed_tensor.dimensions_;
+        if (!result_tensor_out->data_ || !shape_match || result_tensor_out->get_element_count() != final_computed_tensor.get_element_count()) {
+            rocquantum::util::rocTensorFree(result_tensor_out);
+            result_tensor_out->dimensions_ = final_computed_tensor.dimensions_;
+            result_tensor_out->labels_ = final_computed_tensor.labels_;
             result_tensor_out->calculate_strides();
+            // The final result tensor_out should NOT be allocated from the workspace,
+            // as its lifetime is managed by the caller.
             rocqStatus_t alloc_final_status = rocquantum::util::rocTensorAllocate(result_tensor_out);
             if (alloc_final_status != ROCQ_STATUS_SUCCESS) {
-                 rocquantum::util::rocTensorFree(&final_tensor); // Free the computed intermediate
+                 if (final_computed_tensor.owned_) rocquantum::util::rocTensorFree(&final_computed_tensor);
+                 // Workspace memory for final_computed_tensor (if it used workspace) is reclaimed by reset.
                  return alloc_final_status;
             }
-        } else { // Already allocated and shape matches, just update metadata if necessary
-            result_tensor_out->labels_ = final_tensor.labels_;
-            result_tensor_out->calculate_strides(); // Ensure strides are up-to-date
+        } else {
+            result_tensor_out->labels_ = final_computed_tensor.labels_;
+            result_tensor_out->calculate_strides();
         }
 
-        // Copy data from the final active tensor to the user-provided result_tensor_out
-        if (final_tensor.data_ && result_tensor_out->data_ && final_tensor.get_element_count() > 0) {
-            hipError_t copy_err = hipMemcpyAsync(result_tensor_out->data_, final_tensor.data_,
-                                         final_tensor.get_element_count() * sizeof(rocComplex),
+        if (final_computed_tensor.data_ && result_tensor_out->data_ && final_computed_tensor.get_element_count() > 0) {
+            hipError_t copy_err = hipMemcpyAsync(result_tensor_out->data_, final_computed_tensor.data_,
+                                         final_computed_tensor.get_element_count() * sizeof(rocComplex),
                                          hipMemcpyDeviceToDevice, stream);
-            hipError_t sync_err = hipStreamSynchronize(stream);
-            rocquantum::util::rocTensorFree(&final_tensor); // Free the last intermediate
-
-            if (copy_err != hipSuccess || sync_err != hipSuccess) {
-                rocquantum::util::rocTensorFree(result_tensor_out); // Free result if copy failed
+            if (copy_err != hipSuccess) {
+                if (final_computed_tensor.owned_) rocquantum::util::rocTensorFree(&final_computed_tensor);
                 return ROCQ_STATUS_HIP_ERROR;
             }
-        } else if (final_tensor.get_element_count() == 0 && result_tensor_out->get_element_count() == 0) {
-            // Both are 0-element tensors, success.
-            rocquantum::util::rocTensorFree(&final_tensor);
-        } else if (final_tensor.get_element_count() == 1 && result_tensor_out->get_element_count() == 1 && final_tensor.data_ && result_tensor_out->data_) {
-            // Scalar case
-            hipError_t copy_err = hipMemcpyAsync(result_tensor_out->data_, final_tensor.data_, sizeof(rocComplex), hipMemcpyDeviceToDevice, stream);
-            hipError_t sync_err = hipStreamSynchronize(stream);
-            rocquantum::util::rocTensorFree(&final_tensor);
-             if (copy_err != hipSuccess || sync_err != hipSuccess) {
-                rocquantum::util::rocTensorFree(result_tensor_out);
+        } else if (final_computed_tensor.get_element_count() == 0 && result_tensor_out->get_element_count() == 0) {
+            // Success
+        } else if (final_computed_tensor.get_element_count() == 1 && result_tensor_out->get_element_count() == 1 && final_computed_tensor.data_ && result_tensor_out->data_) { // Scalar
+            hipError_t copy_err = hipMemcpyAsync(result_tensor_out->data_, final_computed_tensor.data_, sizeof(rocComplex), hipMemcpyDeviceToDevice, stream);
+            if (copy_err != hipSuccess) {
+                if (final_computed_tensor.owned_) rocquantum::util::rocTensorFree(&final_computed_tensor);
                 return ROCQ_STATUS_HIP_ERROR;
             }
-        }
-         else if (final_tensor.data_ == nullptr && final_tensor.get_element_count() > 0) {
-            // This implies rocTensorContractPair_internal did not produce data for some reason, should have failed earlier.
-             rocquantum::util::rocTensorFree(&final_tensor);
+        } else if (final_computed_tensor.data_ == nullptr && final_computed_tensor.get_element_count() > 0) {
+             if (final_computed_tensor.owned_) rocquantum::util::rocTensorFree(&final_computed_tensor);
              return ROCQ_STATUS_FAILURE;
         }
 
+        // Free the last intermediate if it was heap allocated (owned_ == true)
+        // If it was workspace allocated (owned_ == false), its memory is managed by the workspace reset.
+        if (final_computed_tensor.owned_) {
+            rocquantum::util::rocTensorFree(&final_computed_tensor);
+        }
+        active_tensors_during_contraction_.clear();
 
         return ROCQ_STATUS_SUCCESS;
     } else if (active_tensors_during_contraction_.empty() && initial_tensors_.empty()) {
         return ROCQ_STATUS_INVALID_VALUE;
     } else {
-        // Error: contraction finished with multiple tensors or no tensors.
-        for(auto& t : active_tensors_during_contraction_) rocquantum::util::rocTensorFree(&t);
+        for(auto& t : active_tensors_during_contraction_) {
+            if(t.owned_) rocquantum::util::rocTensorFree(&t);
+        }
+        active_tensors_during_contraction_.clear();
         return ROCQ_STATUS_FAILURE;
     }
 }

--- a/rocquantum/src/hipTensorNet/rocWorkspaceManager.cpp
+++ b/rocquantum/src/hipTensorNet/rocWorkspaceManager.cpp
@@ -1,0 +1,81 @@
+#include "rocquantum/rocWorkspaceManager.h"
+#include "rocquantum/hipStateVec.h" // For checkHipError
+
+namespace rocquantum {
+namespace util {
+
+WorkspaceManager::WorkspaceManager(size_t initial_size_bytes, hipStream_t stream)
+    : d_workspace_ptr_(nullptr),
+      total_size_bytes_(initial_size_bytes),
+      current_offset_bytes_(0),
+      stream_(stream) {
+    if (total_size_bytes_ > 0) {
+        hipError_t err = hipMalloc(&d_workspace_ptr_, total_size_bytes_);
+        if (err != hipSuccess) {
+            // In a real scenario, might throw or log. For now, ptr remains null.
+            // checkHipError(err, "WorkspaceManager hipMalloc"); // Assuming checkHipError exists and handles logging/throwing
+            d_workspace_ptr_ = nullptr; // Ensure it's null on failure
+            total_size_bytes_ = 0;      // and size is 0
+            // Consider throwing std::runtime_error here
+            throw std::runtime_error("WorkspaceManager: hipMalloc failed to allocate workspace of size " + std::to_string(initial_size_bytes));
+        }
+    }
+}
+
+WorkspaceManager::~WorkspaceManager() {
+    if (d_workspace_ptr_) {
+        hipFree(d_workspace_ptr_);
+        d_workspace_ptr_ = nullptr;
+    }
+}
+
+rocComplex* WorkspaceManager::allocate(size_t num_elements) {
+    if (!d_workspace_ptr_ || num_elements == 0) {
+        return nullptr;
+    }
+
+    size_t requested_bytes = num_elements * sizeof(rocComplex);
+    if (requested_bytes == 0) return nullptr; // Should not happen if num_elements > 0
+
+    // Align the current offset
+    size_t aligned_offset = current_offset_bytes_;
+    if (alignment_ > 0 && (current_offset_bytes_ % alignment_) != 0) {
+        aligned_offset = ((current_offset_bytes_ + alignment_ - 1) / alignment_) * alignment_;
+    }
+
+    if (aligned_offset + requested_bytes <= total_size_bytes_) {
+        rocComplex* ptr = reinterpret_cast<rocComplex*>(
+            reinterpret_cast<char*>(d_workspace_ptr_) + aligned_offset
+        );
+        current_offset_bytes_ = aligned_offset + requested_bytes;
+        return ptr;
+    } else {
+        // Not enough space with simple bump allocator
+        // A more sophisticated manager might try to grow the pool or find free blocks.
+        return nullptr;
+    }
+}
+
+void WorkspaceManager::reset() {
+    current_offset_bytes_ = 0;
+}
+
+size_t WorkspaceManager::get_total_size_bytes() const {
+    return total_size_bytes_;
+}
+
+size_t WorkspaceManager::get_used_size_bytes() const {
+    // Return the aligned offset as used, as that's the next allocation start
+    size_t aligned_offset = current_offset_bytes_;
+     if (alignment_ > 0 && (current_offset_bytes_ % alignment_) != 0) {
+        aligned_offset = ((current_offset_bytes_ + alignment_ - 1) / alignment_) * alignment_;
+    }
+    return aligned_offset; // Or current_offset_bytes_ if strict usage without alignment padding is preferred for "used"
+}
+
+hipStream_t WorkspaceManager::get_stream() const {
+    return stream_;
+}
+
+} // namespace util
+} // namespace rocquantum


### PR DESCRIPTION
This commit delivers the core tensor contraction functionality for hipTensorNet and introduces a basic workspace memory manager.

Key changes:

1.  **`rocTensorContractWithRocBLAS` C-API (rocTensorUtil.cpp):
    *   Implemented a parser for simplified Einsum-like strings (e.g.,
      "A(ik),B(kj)->C(ij)" or "ik,kj->ij") to determine contracted and
      uncontracted modes, and the output tensor's structure.
    *   The C-API function now uses this parser to prepare arguments for and call
      an internal C++ helper function `rocTensorContractPair_internal`.
    *   The C-API expects the caller to pre-allocate the result tensor's data
      buffer according to the shape derived from the contraction specification.

2.  **`rocTensorContractPair_internal` (rocTensorUtil.cpp):
    *   This function now contains the core logic for pairwise tensor contraction.
    *   It identifies contracted/uncontracted modes and calculates GEMM parameters (M,N,K).
    *   Generates permutation maps and uses `rocTensorPermute` to reorder modes of
      input tensors, making contracted modes contiguous for GEMM.
    *   Allocates temporary device memory for these permuted tensors.
    *   Calls `rocblas_cgemm` to perform the matrix multiplication.
    *   Frees temporary permuted tensors.

3.  **`WorkspaceManager` (New Component):
    *   Introduced `rocWorkspaceManager.h` and `rocWorkspaceManager.cpp`.
    *   Provides a basic bump allocator for device memory to be used for
      intermediate tensors, aiming to reduce `hipMalloc`/`hipFree` overhead.
    *   Includes `allocate(num_elements)` and `reset()` methods.

4.  **`TensorNetwork::contract` (hipTensorNet.cpp):
    *   Integrated the `WorkspaceManager`. The `TensorNetwork` class now creates
      and owns a default workspace (or can accept an external one).
    *   The `contract` method resets the workspace at the start.
    *   Intermediate tensors are now allocated using `workspace_->allocate()` if a
      workspace is available; otherwise, it falls back to `rocTensorAllocate`.
    *   Correctly manages the `owned_` flag for tensors (false if workspace-managed).
    *   Frees individually owned intermediate tensors that are consumed.
    *   The pathfinding logic remains greedy, now feeding into the implemented
      pairwise contraction.
    *   Handles allocation and data transfer for the final result tensor provided
      by the user.

5.  **Metadata Refinements (`rocTensorUtil.h`, `hipTensorNet.h`):
    *   Added `rocTensor::get_mode_indices_for_label()`.
    *   Removed the obsolete `rocTensorNetworkAddContraction` C-API and related
      class members, as contractions are now found dynamically via labels.

6.  **Build System:**
    *   `rocWorkspaceManager.cpp` added to the `rocqsim_tensornet` library target.

This phase makes `hipTensorNet` capable of performing basic tensor network contractions with improved intermediate memory handling (conceptually, via the workspace). Full Einsum parsing, advanced pathfinding, and more sophisticated workspace strategies are future work.