### PR TITLE
feat: Implement hipStateVec precision, const memory, and rocHybrid v0…

### DIFF
--- a/examples/run_simple_vqe.py
+++ b/examples/run_simple_vqe.py
@@ -1,0 +1,138 @@
+import numpy as np
+from scipy.optimize import minimize
+import rocq # Assuming rocq is installed or in PYTHONPATH
+
+# 1. Define the quantum ansatz using @rocq.kernel
+@rocq.kernel
+def vqe_ansatz_simple(circuit: rocq.Circuit, theta: float, phi: float):
+    """
+    A simple VQE ansatz.
+    Args:
+        circuit: The rocq.Circuit object to apply gates to.
+        theta: Parameter for an Rx gate.
+        phi: Parameter for a CNOT then Rz (example).
+    """
+    # Example: 2-qubit ansatz
+    # Apply Rx(theta) to qubit 0
+    circuit.rx(theta, 0)
+    # Apply CNOT between qubit 0 (control) and qubit 1 (target)
+    if circuit.num_qubits > 1: # Ensure there's a target for CNOT
+        circuit.cx(0, 1)
+        circuit.rz(phi, 1) # Example Rz on target
+    else: # Fallback for 1 qubit case
+        circuit.rz(phi, 0)
+
+
+# 2. Define the Hamiltonian
+# For v0.1, get_expval supports terms like {"Z0": coeff0, "Z1": coeff1}
+# H = 1.0 * Z0 + 0.5 * Z1
+hamiltonian = rocq.PauliOperator({"Z0": 1.0, "Z1": 0.5})
+# Or for a single Z0 term:
+# hamiltonian = rocq.PauliOperator("Z0")
+
+# 3. Define the number of qubits
+NUM_QUBITS = 2
+
+# Create a global simulator instance to avoid re-creation in objective_function
+# This is important as rocsvCreate/Destroy can be relatively expensive.
+# Ensure the simulator is properly managed if the script has a longer lifetime.
+try:
+    global_simulator = rocq.Simulator()
+except Exception as e:
+    print(f"Failed to initialize global ROCQuantum Simulator: {e}")
+    print("Exiting VQE example.")
+    exit()
+
+# 4. Define the objective function for the optimizer
+def objective_function(params):
+    """
+    Calculates the energy (expectation value of the Hamiltonian) for given parameters.
+    """
+    theta = params[0]
+    phi = params[1] if len(params) > 1 else 0.0 # Handle single param case if ansatz changes
+
+    print(f"  VQE Iteration: theta={theta:.4f}, phi={phi:.4f}", end="")
+
+    try:
+        # Build the circuit with current parameters
+        # The circuit is rebuilt in each call for this simple VQE.
+        # A more advanced version would update parameters in an existing program/circuit representation.
+        circuit = rocq.build(vqe_ansatz_simple, NUM_QUBITS, global_simulator, theta, phi)
+
+        # Calculate expectation value
+        energy = rocq.get_expval(circuit, hamiltonian)
+        print(f" -> Energy: {energy:.6f}")
+        return energy
+    except Exception as e:
+        print(f"\nError during objective function evaluation: {e}")
+        # Return a high value to steer optimizer away from problematic parameters
+        return 1e6
+
+
+def run_vqe():
+    print("Starting Simple VQE Example...")
+    print(f"Target Hamiltonian: {hamiltonian}")
+    print(f"Number of Qubits: {NUM_QUBITS}")
+
+    # Initial parameters for the ansatz
+    # For vqe_ansatz_simple with Rx(theta) and Rz(phi)
+    initial_params = np.array([0.5, 0.25]) # theta, phi
+
+    print(f"Initial parameters: {initial_params}")
+
+    # Use SciPy's minimize function
+    # 'COBYLA' is a common choice for VQE as it doesn't require gradients.
+    # Note: For real VQE, noise and shot noise would be factors. This is ideal simulation.
+    try:
+        result = minimize(objective_function,
+                          initial_params,
+                          method='COBYLA',
+                          options={'maxiter': 50, 'disp': False}) # disp=True for more optimizer output
+
+        print("\nOptimization Complete.")
+        print(f"Success: {result.success}")
+        print(f"Message: {result.message}")
+        print(f"Optimal parameters: {result.x}")
+        print(f"Minimum energy found: {result.fun:.6f}")
+
+    except NotImplementedError as nie:
+        print(f"\nOptimization stopped due to a missing feature: {nie}")
+        print("This likely means a backend function for a specific Pauli term in get_expval is not yet implemented.")
+    except RuntimeError as rte:
+        print(f"\nOptimization stopped due to a runtime error: {rte}")
+        print("This could be an issue with the backend simulation or bindings.")
+    except Exception as e:
+        print(f"\nAn unexpected error occurred during optimization: {e}")
+
+    # The global_simulator's handle will be released when global_simulator object is garbage collected
+    # or if we explicitly call global_simulator.release() if that method were added.
+    print("\nVQE Example Finished.")
+
+
+if __name__ == "__main__":
+    if NUM_QUBITS > 10 and global_simulator.handle.get_num_gpus() < 2 : # Arbitrary threshold
+        print(f"Warning: Simulating {NUM_QUBITS} qubits on a single GPU might be slow or run out of memory.")
+
+    # A quick check that the backend is available for Z expectation
+    # This is a bit of a hack. Ideally, the API would allow capability checks.
+    try:
+        print("Checking for Z expectation value support...")
+        temp_circuit = rocq.Circuit(1, global_simulator)
+        temp_hamiltonian = rocq.PauliOperator("Z0")
+        rocq.get_expval(temp_circuit, temp_hamiltonian)
+        print("Z expectation value support seems present.")
+        del temp_circuit # Explicitly delete to free resources sooner
+        run_vqe()
+    except NotImplementedError as e:
+        print(f"VQE cannot run: {e}")
+    except RuntimeError as e:
+         print(f"VQE setup failed with runtime error: {e}")
+    finally:
+        # Explicitly delete the global simulator to ensure its __del__ (and thus RocsvHandleWrapper's __del__)
+        # is called before the script potentially exits and Python's garbage collection order becomes less predictable.
+        # This is good practice for resource cleanup in scripts.
+        if 'global_simulator' in globals():
+            del global_simulator
+            # print("Global simulator explicitly deleted.") # For debug
+
+```

--- a/python/rocq/bindings.cpp
+++ b/python/rocq/bindings.cpp
@@ -274,6 +274,22 @@ PYBIND11_MODULE(_rocq_hip_backend, m) {
         }, py::arg("handle"), py::arg("d_state"), py::arg("num_qubits"), py::arg("qubit_to_measure"),
            "Measures a single qubit. Returns (outcome, probability).");
 
+    m.def("get_expectation_value_z",
+        [](const RocsvHandleWrapper& handle_wrapper, DeviceBuffer& d_state_buffer, unsigned numQubits, unsigned targetQubit) {
+            double result = 0.0;
+            rocqStatus_t status = rocsvGetExpectationValueSinglePauliZ(
+                                               handle_wrapper.get(),
+                                               d_state_buffer.get_ptr<rocComplex>(),
+                                               numQubits,
+                                               targetQubit,
+                                               &result);
+            if (status != ROCQ_STATUS_SUCCESS) {
+                throw std::runtime_error("rocsvGetExpectationValueSinglePauliZ failed: " + std::to_string(status));
+            }
+            return result;
+        }, py::arg("handle"), py::arg("d_state"), py::arg("num_qubits"), py::arg("target_qubit"),
+           "Calculates <Z_k> for the target qubit.");
+
     // Add a helper to create a DeviceBuffer and copy a numpy array to it
     m.def("create_device_matrix_from_numpy",
         [](py::array_t<rocComplex, py::array::c_style | py::array::forcecast> np_array) {

--- a/rocquantum/include/rocquantum/hipStateVec.h
+++ b/rocquantum/include/rocquantum/hipStateVec.h
@@ -3,10 +3,16 @@
 
 #include <hip/hip_runtime.h> // For hipFloatComplex, hipDoubleComplex, hipError_t
 
-// Define rocComplex based on precision (default to float for now)
-// TODO: Add a mechanism to switch precision (e.g., via a compile-time flag)
-typedef hipFloatComplex rocComplex;
-// typedef hipDoubleComplex rocComplex; // For double precision
+// Define rocComplex based on precision
+#ifdef ROCQ_PRECISION_DOUBLE
+    typedef hipDoubleComplex rocComplex;
+    typedef double real_t;
+    const real_t REAL_EPSILON = 1e-12;
+#else
+    typedef hipFloatComplex rocComplex;
+    typedef float real_t;
+    const real_t REAL_EPSILON = 1e-6f;
+#endif
 
 // Opaque handle for hipStateVec resources
 struct rocsvInternalHandle; // Forward declaration
@@ -198,19 +204,19 @@ rocqStatus_t rocsvApplyT(rocsvHandle_t handle, rocComplex* d_state, unsigned num
  * @brief Applies an Rx rotation gate to the target qubit.
  * @param theta Rotation angle in radians.
  */
-rocqStatus_t rocsvApplyRx(rocsvHandle_t handle, rocComplex* d_state, unsigned numQubits, unsigned targetQubit, double theta);
+rocqStatus_t rocsvApplyRx(rocsvHandle_t handle, rocComplex* d_state, unsigned numQubits, unsigned targetQubit, double theta); // theta stays double for API
 
 /**
  * @brief Applies an Ry rotation gate to the target qubit.
  * @param theta Rotation angle in radians.
  */
-rocqStatus_t rocsvApplyRy(rocsvHandle_t handle, rocComplex* d_state, unsigned numQubits, unsigned targetQubit, double theta);
+rocqStatus_t rocsvApplyRy(rocsvHandle_t handle, rocComplex* d_state, unsigned numQubits, unsigned targetQubit, double theta); // theta stays double for API
 
 /**
  * @brief Applies an Rz rotation gate to the target qubit.
  * @param theta Rotation angle in radians.
  */
-rocqStatus_t rocsvApplyRz(rocsvHandle_t handle, rocComplex* d_state, unsigned numQubits, unsigned targetQubit, double theta);
+rocqStatus_t rocsvApplyRz(rocsvHandle_t handle, rocComplex* d_state, unsigned numQubits, unsigned targetQubit, double theta); // theta stays double for API
 
 // --- Two Qubit Specific Gates ---
 
@@ -234,6 +240,25 @@ rocqStatus_t rocsvApplyCZ(rocsvHandle_t handle, rocComplex* d_state, unsigned nu
  * @param qubit2 Index of the second qubit.
  */
 rocqStatus_t rocsvApplySWAP(rocsvHandle_t handle, rocComplex* d_state, unsigned numQubits, unsigned qubit1, unsigned qubit2);
+
+/**
+ * @brief Calculates the expectation value of a single Pauli Z operator on a target qubit.
+ * <psi|Z_k|psi> = P(k=0) - P(k=1)
+ *
+ * @param[in] handle The hipStateVec handle.
+ * @param[in] d_state Pointer to the device state vector. For multi-GPU, this is legacy and the
+ *                    state from the handle's distributed slices is used. For single GPU, this must match
+ *                    the allocated state in the handle.
+ * @param[in] numQubits Total number of qubits in the state vector.
+ * @param[in] targetQubit The global index of the qubit for which to calculate <Z>.
+ * @param[out] result Pointer to store the expectation value (a double).
+ * @return rocqStatus_t Status of the operation.
+ */
+rocqStatus_t rocsvGetExpectationValueSinglePauliZ(rocsvHandle_t handle,
+                                                  rocComplex* d_state,
+                                                  unsigned numQubits,
+                                                  unsigned targetQubit,
+                                                  double* result);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/rocquantum/src/hipStateVec/measurement_kernels.hip
+++ b/rocquantum/src/hipStateVec/measurement_kernels.hip
@@ -12,18 +12,18 @@
 __global__ void calculate_prob0_kernel(const rocComplex* state,
                                        unsigned numQubits, // Total qubits in this state vector (slice)
                                        unsigned targetQubit, // Local index of target qubit in this slice
-                                       double* d_prob0_sum) { // Device pointer for sum
+                                       real_t* d_prob0_sum) { // Device pointer for sum (use real_t)
     size_t N = 1ULL << numQubits;
     // size_t k = 1ULL << targetQubit; // Stride related to targetQubit
 
     // HACK: Only one thread does the sum for now to avoid race for this placeholder
     if (threadIdx.x == 0 && blockIdx.x == 0) {
-        double p0 = 0.0;
+        real_t p0 = 0.0;
         if (N > 0) { // Ensure state is not empty (e.g. 0 local qubits for this slice)
             for (size_t i = 0; i < N; ++i) {
                 // Check if the targetQubit bit is 0 for state i
                 if (((i >> targetQubit) & 1) == 0) {
-                    p0 += (double)state[i].x * state[i].x + (double)state[i].y * state[i].y;
+                    p0 += (real_t)state[i].x * state[i].x + (real_t)state[i].y * state[i].y;
                 }
             }
         }
@@ -44,9 +44,17 @@ __global__ void collapse_state_kernel(rocComplex* state,
     if (tid < N) { // Check bounds for the current slice
         bool targetQubitIsOne = ((tid >> targetQubit) & 1);
         if (measuredOutcome == 0 && targetQubitIsOne) { // Measured 0, so zero out states where qubit is 1
-            state[tid] = make_hipFloatComplex(0.0f, 0.0f);
+#ifdef ROCQ_PRECISION_DOUBLE
+            state[tid] = {0.0, 0.0};
+#else
+            state[tid] = {0.0f, 0.0f};
+#endif
         } else if (measuredOutcome == 1 && !targetQubitIsOne) { // Measured 1, so zero out states where qubit is 0
-            state[tid] = make_hipFloatComplex(0.0f, 0.0f);
+#ifdef ROCQ_PRECISION_DOUBLE
+            state[tid] = {0.0, 0.0};
+#else
+            state[tid] = {0.0f, 0.0f};
+#endif
         }
         // Else, the amplitude remains (it's part of the collapsed state)
     }
@@ -58,7 +66,7 @@ __global__ void collapse_state_kernel(rocComplex* state,
 // amp_i_new = amp_i_old * norm_factor
 __global__ void renormalize_state_kernel(rocComplex* state,
                                          unsigned numQubits, // Total qubits in this state vector (slice)
-                                         double d_sum_sq_mag_inv_sqrt) { // Pass 1.0/sqrt(sum_sq_mag)
+                                         real_t d_sum_sq_mag_inv_sqrt) { // Pass 1.0/sqrt(sum_sq_mag) (use real_t)
     size_t N = 1ULL << numQubits;
     size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -72,14 +80,14 @@ __global__ void renormalize_state_kernel(rocComplex* state,
 // THIS IS A PLACEHOLDER KERNEL LOGIC (SINGLE GPU CONTEXT)
 __global__ void sum_sq_magnitudes_kernel(const rocComplex* state,
                                          unsigned numQubits, // Total qubits in this state vector (slice)
-                                         double* d_sum_sq_mag) {
+                                         real_t* d_sum_sq_mag) { // Use real_t
     size_t N = 1ULL << numQubits;
     // HACK: Single thread calculation for now
     if (threadIdx.x == 0 && blockIdx.x == 0) {
-        double current_sum_sq_mag = 0.0;
+        real_t current_sum_sq_mag = 0.0;
         if (N > 0) {
             for (size_t i = 0; i < N; ++i) {
-                current_sum_sq_mag += (double)state[i].x * state[i].x + (double)state[i].y * state[i].y;
+                current_sum_sq_mag += (real_t)state[i].x * state[i].x + (real_t)state[i].y * state[i].y;
             }
         }
         *d_sum_sq_mag = current_sum_sq_mag;
@@ -90,29 +98,29 @@ __global__ void sum_sq_magnitudes_kernel(const rocComplex* state,
 // --- New Kernels for Multi-GPU Measurement ---
 
 // Performs a block-level reduction to calculate sum of probabilities for |0> and |1> states of a target qubit.
-// Output d_block_partial_probs must be pre-allocated to hold 2 * gridDim.x doubles.
+// Output d_block_partial_probs must be pre-allocated to hold 2 * gridDim.x real_ts.
 // Each block writes its two sums (prob0_block, prob1_block) to its designated slot.
 __global__ void calculate_local_slice_probabilities_kernel(
     const rocComplex* local_slice_data,
     size_t local_slice_num_elements,    // Number of elements in this GPU's slice
     unsigned num_local_qubits,          // Number of qubits represented by local_slice_data
     unsigned local_target_qubit,        // Index of the qubit to measure (local to this slice)
-    double* d_block_partial_probs) {    // Output: array for [block0_p0, block0_p1, block1_p0, block1_p1, ...]
+    real_t* d_block_partial_probs) {    // Output: array for [block0_p0, block0_p1, block1_p0, block1_p1, ...] (use real_t)
 
-    extern __shared__ double sdata[]; // Shared memory for reduction, size: blockDim.x * 2 doubles
+    extern __shared__ real_t sdata[]; // Shared memory for reduction, size: blockDim.x * 2 real_ts
 
     unsigned int tid_in_block = threadIdx.x;
     size_t global_idx_start = blockIdx.x * blockDim.x;
 
-    double my_prob0 = 0.0;
-    double my_prob1 = 0.0;
+    real_t my_prob0 = 0.0;
+    real_t my_prob1 = 0.0;
 
     // Each thread processes multiple elements if necessary (grid-stride loop)
     for (size_t i = tid_in_block; i < blockDim.x; i += blockDim.x) { // This loop is over elements within a block's responsibility
         size_t current_local_idx = global_idx_start + i;
         if (current_local_idx < local_slice_num_elements) {
             rocComplex amp = local_slice_data[current_local_idx];
-            double mag_sq = (double)amp.x * amp.x + (double)amp.y * amp.y;
+            real_t mag_sq = (real_t)amp.x * amp.x + (real_t)amp.y * amp.y;
 
             if (((current_local_idx >> local_target_qubit) & 1) == 0) { // Qubit is |0>
                 my_prob0 += mag_sq;
@@ -150,25 +158,25 @@ __global__ void calculate_local_slice_probabilities_kernel(
 
 
 // Performs a block-level reduction for sum of squared magnitudes.
-// Output d_block_sum_sq_mag must be pre-allocated to hold gridDim.x doubles.
+// Output d_block_sum_sq_mag must be pre-allocated to hold gridDim.x real_ts.
 // Each block writes its sum to its designated slot.
 __global__ void calculate_local_slice_sum_sq_mag_kernel(
     const rocComplex* local_slice_data,
     size_t local_slice_num_elements,    // Number of elements in this GPU's slice
-    double* d_block_sum_sq_mag) {       // Output: array for [block0_sum, block1_sum, ...]
+    real_t* d_block_sum_sq_mag) {       // Output: array for [block0_sum, block1_sum, ...] (use real_t)
 
-    extern __shared__ double sdata_sum[]; // Shared memory for reduction, size: blockDim.x doubles
+    extern __shared__ real_t sdata_sum[]; // Shared memory for reduction, size: blockDim.x real_ts
 
     unsigned int tid_in_block = threadIdx.x;
     size_t global_idx_start = blockIdx.x * blockDim.x;
 
-    double my_sum_sq = 0.0;
+    real_t my_sum_sq = 0.0;
 
     for (size_t i = tid_in_block; i < blockDim.x; i += blockDim.x) {
         size_t current_local_idx = global_idx_start + i;
         if (current_local_idx < local_slice_num_elements) {
             rocComplex amp = local_slice_data[current_local_idx];
-            my_sum_sq += (double)amp.x * amp.x + (double)amp.y * amp.y;
+            my_sum_sq += (real_t)amp.x * amp.x + (real_t)amp.y * amp.y;
         }
     }
 
@@ -193,16 +201,16 @@ __global__ void calculate_local_slice_sum_sq_mag_kernel(
 // Assumes this kernel is launched with enough threads/blocks to efficiently sum d_block_partial_probs.
 // For simplicity, this can be a single block if num_blocks is not excessively large (e.g., < 1024*2).
 __global__ void reduce_block_sums_to_slice_total_probs_kernel(
-    const double* d_block_partial_probs, // Flattened array: [b0p0, b0p1, b1p0, b1p1, ...]
+    const real_t* d_block_partial_probs, // Flattened array: [b0p0, b0p1, b1p0, b1p1, ...] (use real_t)
     unsigned num_blocks_from_previous_kernel,
-    double* d_slice_total_probs_out) { // Output: [total_p0, total_p1]
+    real_t* d_slice_total_probs_out) { // Output: [total_p0, total_p1] (use real_t)
 
-    extern __shared__ double s_reduce_probs[]; // Shared memory, size: blockDim.x * 2 for p0 and p1 sums
+    extern __shared__ real_t s_reduce_probs[]; // Shared memory, size: blockDim.x * 2 for p0 and p1 sums
 
     unsigned int tid = threadIdx.x;
 
-    double my_p0_sum = 0.0;
-    double my_p1_sum = 0.0;
+    real_t my_p0_sum = 0.0;
+    real_t my_p1_sum = 0.0;
 
     // Each thread sums a portion of the d_block_partial_probs array
     // This loop structure assumes this kernel is launched with a single block,
@@ -243,13 +251,13 @@ __global__ void reduce_block_sums_to_slice_total_probs_kernel(
 // d_block_sum_sq_mag: input array of size num_blocks.
 // d_slice_total_sum_sq_mag_out: output array of size 1.
 __global__ void reduce_block_sums_to_slice_total_sum_sq_mag_kernel(
-    const double* d_block_sum_sq_mag_in, // Array of sums from each block of previous kernel
+    const real_t* d_block_sum_sq_mag_in, // Array of sums from each block of previous kernel (use real_t)
     unsigned num_blocks_from_previous_kernel,
-    double* d_slice_total_sum_sq_mag_out) { // Output: single double for the slice's total sum_sq_mag
+    real_t* d_slice_total_sum_sq_mag_out) { // Output: single real_t for the slice's total sum_sq_mag
 
-    extern __shared__ double s_reduce_sum_sq[]; // Shared memory, size: blockDim.x
+    extern __shared__ real_t s_reduce_sum_sq[]; // Shared memory, size: blockDim.x
     unsigned int tid = threadIdx.x;
-    double my_sum = 0.0;
+    real_t my_sum = 0.0;
 
     for (unsigned i = tid; i < num_blocks_from_previous_kernel; i += blockDim.x) {
         my_sum += d_block_sum_sq_mag_in[i];

--- a/rocquantum/src/hipStateVec/multi_qubit_kernels.hip
+++ b/rocquantum/src/hipStateVec/multi_qubit_kernels.hip
@@ -12,7 +12,11 @@ __device__ inline void apply_small_matrix_local(rocComplex* local_amps,
 
     for (unsigned i = 0; i < matrix_dim; ++i) {
         temp_amps[i] = local_amps[i]; // Copy to temp array
-        local_amps[i] = make_hipFloatComplex(0.0f, 0.0f); // Zero out for accumulation
+#ifdef ROCQ_PRECISION_DOUBLE
+        local_amps[i] = {0.0, 0.0}; // Zero out for accumulation
+#else
+        local_amps[i] = {0.0f, 0.0f}; // Zero out for accumulation
+#endif
     }
 
     for (unsigned i = 0; i < matrix_dim; ++i) { // Output amplitude index

--- a/rocquantum/src/hipStateVec/single_qubit_kernels.hip
+++ b/rocquantum/src/hipStateVec/single_qubit_kernels.hip
@@ -1,5 +1,10 @@
 #include <hip/hip_runtime.h>
-#include "rocquantum/hipStateVec.h" // For rocComplex definition
+#include "rocquantum/hipStateVec.h" // For rocComplex, real_t definition
+
+// Constant memory for the 2x2 single-qubit matrix used by apply_single_qubit_generic_matrix_kernel
+// This matrix is copied here by the host before launching the kernel.
+// Only one such matrix can be "active" in constant memory at a time for this specific kernel.
+__constant__ rocComplex const_single_q_matrix[4];
 
 // Convention: Qubit 0 is the LSB.
 // For a single qubit gate on qubit 'targetQubit':
@@ -27,10 +32,10 @@ __device__ inline void apply_1q_matrix(rocComplex& amp0, rocComplex& amp1, const
 }
 
 // Generic kernel for applying an arbitrary 1-qubit unitary matrix
+// Matrix is read from __constant__ memory symbol const_single_q_matrix
 __global__ void apply_single_qubit_generic_matrix_kernel(rocComplex* state,
                                                          unsigned numQubits,
-                                                         unsigned targetQubit,
-                                                         const rocComplex* matrix) {
+                                                         unsigned targetQubit) { // Matrix parameter removed
     size_t N = 1ULL << numQubits;
     size_t k = 1ULL << targetQubit; // Stride between paired amplitudes
 
@@ -61,7 +66,8 @@ __global__ void apply_single_qubit_generic_matrix_kernel(rocComplex* state,
     if (idx1 < N) { // Ensure both indices are within bounds
         rocComplex amp0 = state[idx0];
         rocComplex amp1 = state[idx1];
-        apply_1q_matrix(amp0, amp1, matrix);
+        // apply_1q_matrix reads from const_single_q_matrix directly
+        apply_1q_matrix(amp0, amp1, const_single_q_matrix);
         state[idx0] = amp0;
         state[idx1] = amp1;
     }
@@ -113,12 +119,18 @@ __global__ void apply_Y_kernel(rocComplex* state, unsigned numQubits, unsigned t
         rocComplex amp1_old = state[idx1];
 
         // amp0_new = -i * amp1_old = {amp1_old.y, -amp1_old.x}
+#ifdef ROCQ_PRECISION_DOUBLE
         state[idx0].x = amp1_old.y;
         state[idx0].y = -amp1_old.x;
-
         // amp1_new = i * amp0_old = {-amp0_old.y, amp0_old.x}
         state[idx1].x = -amp0_old.y;
         state[idx1].y = amp0_old.x;
+#else
+        state[idx0].x = amp1_old.y;
+        state[idx0].y = -amp1_old.x;
+        state[idx1].x = -amp0_old.y;
+        state[idx1].y = amp0_old.x;
+#endif
     }
 }
 
@@ -149,7 +161,11 @@ __global__ void apply_H_kernel(rocComplex* state, unsigned numQubits, unsigned t
     // H = 1/sqrt(2) * [[1, 1], [1, -1]]
     // amp0_new = (amp0_old + amp1_old) / sqrt(2)
     // amp1_new = (amp0_old - amp1_old) / sqrt(2)
-    const float inv_sqrt2 = 1.0f / sqrtf(2.0f);
+#ifdef ROCQ_PRECISION_DOUBLE
+    const real_t inv_sqrt2 = 1.0 / sqrt(2.0);
+#else
+    const real_t inv_sqrt2 = 1.0f / sqrtf(2.0f);
+#endif
     size_t N = 1ULL << numQubits;
     size_t k = 1ULL << targetQubit;
     size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -191,8 +207,13 @@ __global__ void apply_S_kernel(rocComplex* state, unsigned numQubits, unsigned t
 
     if (idx1 < N) {
         rocComplex amp1_old = state[idx1];
+#ifdef ROCQ_PRECISION_DOUBLE
         state[idx1].x = -amp1_old.y;
         state[idx1].y = amp1_old.x;
+#else
+        state[idx1].x = -amp1_old.y;
+        state[idx1].y = amp1_old.x;
+#endif
     }
 }
 
@@ -200,8 +221,13 @@ __global__ void apply_S_kernel(rocComplex* state, unsigned numQubits, unsigned t
 __global__ void apply_T_kernel(rocComplex* state, unsigned numQubits, unsigned targetQubit) {
     // T = [[1, 0], [0, exp(i*pi/4)]]
     // exp(i*pi/4) = cos(pi/4) + i*sin(pi/4) = 1/sqrt(2) + i/sqrt(2)
-    const float val = 1.0f / sqrtf(2.0f);
-    rocComplex phase_factor = make_hipFloatComplex(val, val);
+#ifdef ROCQ_PRECISION_DOUBLE
+    const real_t val = 1.0 / sqrt(2.0);
+    rocComplex phase_factor = {val, val};
+#else
+    const real_t val = 1.0f / sqrtf(2.0f);
+    rocComplex phase_factor = {val, val};
+#endif
     
     size_t N = 1ULL << numQubits;
     size_t k = 1ULL << targetQubit;
@@ -222,16 +248,24 @@ __global__ void apply_T_kernel(rocComplex* state, unsigned numQubits, unsigned t
 }
 
 // Rx(theta) Gate
-__global__ void apply_Rx_kernel(rocComplex* state, unsigned numQubits, unsigned targetQubit, float theta) {
+__global__ void apply_Rx_kernel(rocComplex* state, unsigned numQubits, unsigned targetQubit, real_t theta) {
     // Rx(theta) = [[cos(t/2), -i*sin(t/2)], [-i*sin(t/2), cos(t/2)]]
     // M00 = cos(t/2), M01 = {0, -sin(t/2)}, M10 = {0, -sin(t/2)}, M11 = cos(t/2)
-    float cos_half_theta = cosf(theta / 2.0f);
-    float sin_half_theta = sinf(theta / 2.0f);
-
-    rocComplex M00 = make_hipFloatComplex(cos_half_theta, 0.0f);
-    rocComplex M01 = make_hipFloatComplex(0.0f, -sin_half_theta);
-    rocComplex M10 = make_hipFloatComplex(0.0f, -sin_half_theta);
-    rocComplex M11 = make_hipFloatComplex(cos_half_theta, 0.0f);
+#ifdef ROCQ_PRECISION_DOUBLE
+    real_t cos_half_theta = cos(theta / 2.0);
+    real_t sin_half_theta = sin(theta / 2.0);
+    rocComplex M00 = {cos_half_theta, 0.0};
+    rocComplex M01 = {0.0, -sin_half_theta};
+    rocComplex M10 = {0.0, -sin_half_theta};
+    rocComplex M11 = {cos_half_theta, 0.0};
+#else
+    real_t cos_half_theta = cosf(theta / 2.0f);
+    real_t sin_half_theta = sinf(theta / 2.0f);
+    rocComplex M00 = {cos_half_theta, 0.0f};
+    rocComplex M01 = {0.0f, -sin_half_theta};
+    rocComplex M10 = {0.0f, -sin_half_theta};
+    rocComplex M11 = {cos_half_theta, 0.0f};
+#endif
     
     // This can be directly passed to the generic kernel as well
     // For now, let's use the structure of other specialized kernels
@@ -259,16 +293,24 @@ __global__ void apply_Rx_kernel(rocComplex* state, unsigned numQubits, unsigned 
 }
 
 // Ry(theta) Gate
-__global__ void apply_Ry_kernel(rocComplex* state, unsigned numQubits, unsigned targetQubit, float theta) {
+__global__ void apply_Ry_kernel(rocComplex* state, unsigned numQubits, unsigned targetQubit, real_t theta) {
     // Ry(theta) = [[cos(t/2), -sin(t/2)], [sin(t/2), cos(t/2)]]
     // M00 = cos(t/2), M01 = -sin(t/2), M10 = sin(t/2), M11 = cos(t/2)
-    float cos_half_theta = cosf(theta / 2.0f);
-    float sin_half_theta = sinf(theta / 2.0f);
-
-    rocComplex M00 = make_hipFloatComplex(cos_half_theta, 0.0f);
-    rocComplex M01 = make_hipFloatComplex(-sin_half_theta, 0.0f);
-    rocComplex M10 = make_hipFloatComplex(sin_half_theta, 0.0f);
-    rocComplex M11 = make_hipFloatComplex(cos_half_theta, 0.0f);
+#ifdef ROCQ_PRECISION_DOUBLE
+    real_t cos_half_theta = cos(theta / 2.0);
+    real_t sin_half_theta = sin(theta / 2.0);
+    rocComplex M00 = {cos_half_theta, 0.0};
+    rocComplex M01 = {-sin_half_theta, 0.0};
+    rocComplex M10 = {sin_half_theta, 0.0};
+    rocComplex M11 = {cos_half_theta, 0.0};
+#else
+    real_t cos_half_theta = cosf(theta / 2.0f);
+    real_t sin_half_theta = sinf(theta / 2.0f);
+    rocComplex M00 = {cos_half_theta, 0.0f};
+    rocComplex M01 = {-sin_half_theta, 0.0f};
+    rocComplex M10 = {sin_half_theta, 0.0f};
+    rocComplex M11 = {cos_half_theta, 0.0f};
+#endif
 
     size_t N = 1ULL << numQubits;
     size_t k = 1ULL << targetQubit;
@@ -294,15 +336,21 @@ __global__ void apply_Ry_kernel(rocComplex* state, unsigned numQubits, unsigned 
 }
 
 // Rz(theta) Gate (Phase shift)
-__global__ void apply_Rz_kernel(rocComplex* state, unsigned numQubits, unsigned targetQubit, float theta) {
+__global__ void apply_Rz_kernel(rocComplex* state, unsigned numQubits, unsigned targetQubit, real_t theta) {
     // Rz(theta) = [[exp(-it/2), 0], [0, exp(it/2)]]
     // amp0_new = exp(-it/2) * amp0_old
     // amp1_new = exp(it/2) * amp1_old
-    float cos_half_theta = cosf(theta / 2.0f);
-    float sin_half_theta = sinf(theta / 2.0f);
-
-    rocComplex phase_neg = make_hipFloatComplex(cos_half_theta, -sin_half_theta); // e^(-it/2)
-    rocComplex phase_pos = make_hipFloatComplex(cos_half_theta, sin_half_theta);  // e^(it/2)
+#ifdef ROCQ_PRECISION_DOUBLE
+    real_t cos_half_theta = cos(theta / 2.0);
+    real_t sin_half_theta = sin(theta / 2.0);
+    rocComplex phase_neg = {cos_half_theta, -sin_half_theta}; // e^(-it/2)
+    rocComplex phase_pos = {cos_half_theta, sin_half_theta};  // e^(it/2)
+#else
+    real_t cos_half_theta = cosf(theta / 2.0f);
+    real_t sin_half_theta = sinf(theta / 2.0f);
+    rocComplex phase_neg = {cos_half_theta, -sin_half_theta}; // e^(-it/2)
+    rocComplex phase_pos = {cos_half_theta, sin_half_theta};  // e^(it/2)
+#endif
 
     size_t N = 1ULL << numQubits;
     size_t k = 1ULL << targetQubit;

--- a/rocquantum/src/hipTensorNet/test_hipTensorNet_rocTensorUtil.cpp
+++ b/rocquantum/src/hipTensorNet/test_hipTensorNet_rocTensorUtil.cpp
@@ -1,0 +1,888 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include <numeric>
+#include <algorithm>
+#include <cmath> // For std::abs
+#include <stdexcept> // For runtime_error
+
+#include "rocquantum/hipTensorNet.h"
+#include "rocquantum/rocTensorUtil.h"
+#include "rocquantum/rocWorkspaceManager.h"
+#include "rocquantum/hipStateVec.h" // For rocComplex and rocqStatus_t
+
+#include <hip/hip_runtime.h>
+#include <rocblas/rocblas.h>
+
+// Helper to check HIP errors
+#define HIP_ASSERT(x) do { \
+    hipError_t err = x; \
+    if (err != hipSuccess) { \
+        std::cerr << "HIP Error: " << hipGetErrorString(err) << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
+        throw std::runtime_error("HIP Error"); \
+    } \
+} while (0)
+
+// Helper to check ROCBLAS errors
+#define ROCBLAS_ASSERT(x) do { \
+    rocblas_status err = x; \
+    if (err != rocblas_status_success) { \
+        std::cerr << "rocBLAS Error: " << err << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
+        throw std::runtime_error("rocBLAS Error"); \
+    } \
+} while (0)
+
+// Basic Assertion Macros
+#define ASSERT_EQ(val1, val2, test_name) do { \
+    if ((val1) != (val2)) { \
+        std::cerr << "Assertion failed in " << (test_name) << ": " << (val1) << " != " << (val2) << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
+        return false; \
+    } \
+} while (0)
+
+#define ASSERT_TRUE(cond, test_name) do { \
+    if (!(cond)) { \
+        std::cerr << "Assertion failed in " << (test_name) << ": condition is false at " << __FILE__ << ":" << __LINE__ << std::endl; \
+        return false; \
+    } \
+} while (0)
+
+#define ASSERT_FALSE(cond, test_name) do { \
+    if (cond) { \
+        std::cerr << "Assertion failed in " << (test_name) << ": condition is true at " << __FILE__ << ":" << __LINE__ << std::endl; \
+        return false; \
+    } \
+} while (0)
+
+const float COMPLEX_EPSILON = 1e-5f;
+
+bool compare_rocComplex(rocComplex c1, rocComplex c2, float epsilon = COMPLEX_EPSILON) {
+    return (std::abs(c1.x - c2.x) < epsilon) && (std::abs(c1.y - c2.y) < epsilon);
+}
+
+#define ASSERT_COMPLEX_EQ(c1, c2, test_name) do { \
+    if (!compare_rocComplex(c1, c2)) { \
+        std::cerr << "Assertion failed in " << (test_name) << ": (" << (c1).x << "," << (c1).y << ") != (" \
+                  << (c2).x << "," << (c2).y << ") at " << __FILE__ << ":" << __LINE__ << std::endl; \
+        return false; \
+    } \
+} while (0)
+
+#define ASSERT_COMPLEX_VEC_EQ(vec1_h, vec2_d, size, test_name) do { \
+    std::vector<rocComplex> vec2_h(size); \
+    HIP_ASSERT(hipMemcpy(vec2_h.data(), vec2_d, size * sizeof(rocComplex), hipMemcpyDeviceToHost)); \
+    for (size_t i = 0; i < size; ++i) { \
+        if (!compare_rocComplex(vec1_h[i], vec2_h[i])) { \
+            std::cerr << "Assertion failed in " << (test_name) << " at index " << i << ": (" \
+                      << vec1_h[i].x << "," << vec1_h[i].y << ") != (" \
+                      << vec2_h[i].x << "," << vec2_h[i].y << ") at " << __FILE__ << ":" << __LINE__ << std::endl; \
+            return false; \
+        } \
+    } \
+} while(0)
+
+
+// Test Runner
+typedef bool (*TestFunc)();
+std::vector<std::pair<std::string, TestFunc>> tests;
+
+#define ADD_TEST(name) tests.push_back({#name, name})
+
+void RUN_ALL_TESTS() {
+    int passed_count = 0;
+    int failed_count = 0;
+    std::cout << "Running " << tests.size() << " tests..." << std::endl;
+    for (const auto& test_pair : tests) {
+        std::cout << "----------------------------------------" << std::endl;
+        std::cout << "Running test: " << test_pair.first << "..." << std::endl;
+        bool result = false;
+        try {
+            result = test_pair.second();
+        } catch (const std::runtime_error& e) {
+            std::cerr << "Test " << test_pair.first << " threw an exception: " << e.what() << std::endl;
+            result = false;
+        } catch (...) {
+            std::cerr << "Test " << test_pair.first << " threw an unknown exception." << std::endl;
+            result = false;
+        }
+
+        if (result) {
+            std::cout << "Test " << test_pair.first << ": PASSED" << std::endl;
+            passed_count++;
+        } else {
+            std::cout << "Test " << test_pair.first << ": FAILED" << std::endl;
+            failed_count++;
+        }
+    }
+    std::cout << "----------------------------------------" << std::endl;
+    std::cout << "All tests completed." << std::endl;
+    std::cout << "Passed: " << passed_count << ", Failed: " << failed_count << std::endl;
+    if (failed_count > 0) {
+        // Consider exiting with non-zero status for CI
+        // exit(1);
+    }
+}
+
+// Global rocBLAS handle and stream for tests
+rocblas_handle blas_handle = nullptr;
+hipStream_t test_stream = 0;
+
+void setup_global_test_resources() {
+    HIP_ASSERT(hipStreamCreate(&test_stream));
+    ROCBLAS_ASSERT(rocblas_create_handle(&blas_handle));
+    ROCBLAS_ASSERT(rocblas_set_stream(blas_handle, test_stream));
+}
+
+void teardown_global_test_resources() {
+    if (blas_handle) ROCBLAS_ASSERT(rocblas_destroy_handle(blas_handle));
+    if (test_stream) HIP_ASSERT(hipStreamDestroy(test_stream));
+    blas_handle = nullptr;
+    test_stream = 0;
+}
+
+// ---------- rocTensorUtil Tests ----------
+
+bool test_rocTensor_struct() {
+    std::cout << "  Sub-test: rocTensor struct basics..." << std::endl;
+    rocquantum::util::rocTensor tensor;
+    ASSERT_EQ(tensor.data_, nullptr, "rocTensor_struct.default_data");
+    ASSERT_EQ(tensor.rank(), 0, "rocTensor_struct.default_rank");
+    ASSERT_EQ(tensor.get_element_count(), 0, "rocTensor_struct.default_elements");
+    ASSERT_FALSE(tensor.owned_, "rocTensor_struct.default_owned");
+
+    std::vector<long long> dims = {2, 3, 4};
+    rocComplex* dummy_data = reinterpret_cast<rocComplex*>(0x1234); // Just a non-null pointer
+    rocquantum::util::rocTensor tensor2(dummy_data, dims);
+    ASSERT_EQ(tensor2.data_, dummy_data, "rocTensor_struct.init_data");
+    ASSERT_EQ(tensor2.rank(), 3, "rocTensor_struct.init_rank");
+    ASSERT_EQ(tensor2.get_element_count(), 24, "rocTensor_struct.init_elements");
+    ASSERT_FALSE(tensor2.owned_, "rocTensor_struct.init_owned");
+    ASSERT_EQ(tensor2.dimensions_.size(), 3, "rocTensor_struct.dims_size");
+    ASSERT_EQ(tensor2.strides_.size(), 3, "rocTensor_struct.strides_size");
+    if (tensor2.strides_.size() == 3) { // Check strides if correctly sized
+        ASSERT_EQ(tensor2.strides_[0], 1, "rocTensor_struct.stride0");
+        ASSERT_EQ(tensor2.strides_[1], 2, "rocTensor_struct.stride1");
+        ASSERT_EQ(tensor2.strides_[2], 6, "rocTensor_struct.stride2");
+    }
+
+    // Test scalar-like (empty dims)
+    rocquantum::util::rocTensor scalar_tensor(dummy_data, {});
+    ASSERT_EQ(scalar_tensor.get_element_count(), 0, "rocTensor_struct.scalar_elements_empty_dims"); // 0 based on product
+    // The `rocTensorAllocate` handles scalar by allocating 1 element. `rocTensor` itself has 0 elements if dims is empty.
+
+    // Test move constructor
+    rocquantum::util::rocTensor tensor3 = std::move(tensor2);
+    ASSERT_EQ(tensor3.data_, dummy_data, "rocTensor_struct.move_ctor_data");
+    ASSERT_EQ(tensor3.rank(), 3, "rocTensor_struct.move_ctor_rank");
+    ASSERT_FALSE(tensor3.owned_, "rocTensor_struct.move_ctor_owned"); // Ownership doesn't change by default on move of a view
+    ASSERT_EQ(tensor2.data_, nullptr, "rocTensor_struct.moved_from_data_null");
+    ASSERT_FALSE(tensor2.owned_, "rocTensor_struct.moved_from_owned_false");
+
+
+    std::cout << "  Sub-test: rocTensor struct basics PASSED." << std::endl;
+    return true;
+}
+
+bool test_rocTensor_alloc_free() {
+    std::cout << "  Sub-test: rocTensorAllocate and rocTensorFree..." << std::endl;
+    rocquantum::util::rocTensor tensor;
+    tensor.dimensions_ = {2, 2};
+
+    rocqStatus_t status = rocquantum::util::rocTensorAllocate(&tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "alloc_free.allocate_status");
+    ASSERT_TRUE(tensor.data_ != nullptr, "alloc_free.data_not_null_after_alloc");
+    ASSERT_TRUE(tensor.owned_, "alloc_free.owned_true_after_alloc");
+    ASSERT_EQ(tensor.get_element_count(), 4, "alloc_free.element_count");
+
+    // Test double allocation (should free old and alloc new)
+    tensor.dimensions_ = {3,3};
+    status = rocquantum::util::rocTensorAllocate(&tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "alloc_free.re_allocate_status");
+    ASSERT_TRUE(tensor.data_ != nullptr, "alloc_free.data_not_null_after_realloc");
+    ASSERT_TRUE(tensor.owned_, "alloc_free.owned_true_after_realloc");
+    ASSERT_EQ(tensor.get_element_count(), 9, "alloc_free.element_count_realloc");
+
+
+    status = rocquantum::util::rocTensorFree(&tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "alloc_free.free_status");
+    ASSERT_EQ(tensor.data_, nullptr, "alloc_free.data_null_after_free");
+    ASSERT_FALSE(tensor.owned_, "alloc_free.owned_false_after_free");
+
+    // Test freeing a non-owned tensor (should be a no-op, clear view)
+    rocComplex* dummy_data = reinterpret_cast<rocComplex*>(0x1234);
+    tensor.data_ = dummy_data;
+    tensor.owned_ = false;
+    tensor.dimensions_ = {1,1};
+    status = rocquantum::util::rocTensorFree(&tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "alloc_free.free_non_owned_status");
+    ASSERT_EQ(tensor.data_, nullptr, "alloc_free.data_null_after_free_non_owned"); // Clears view
+    ASSERT_FALSE(tensor.owned_, "alloc_free.owned_false_after_free_non_owned");
+
+    // Test scalar (empty dims, allocate should make it 1 element)
+    rocquantum::util::rocTensor scalar_tensor;
+    scalar_tensor.dimensions_ = {}; // Empty
+    status = rocquantum::util::rocTensorAllocate(&scalar_tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "alloc_free.scalar_alloc_status");
+    ASSERT_TRUE(scalar_tensor.data_ != nullptr, "alloc_free.scalar_data_not_null");
+    ASSERT_TRUE(scalar_tensor.owned_, "alloc_free.scalar_owned");
+    // rocTensorAllocate treats empty dims as a scalar of 1 element for allocation purposes
+    ASSERT_EQ(scalar_tensor.get_element_count(), 0, "alloc_free.scalar_original_element_count"); // original count is 0
+    // Check allocated size by trying to write to it (not directly testable without element count change)
+    // For now, trust hipMalloc(sizeof(rocComplex)) worked.
+    rocComplex test_val = {1.0f, 2.0f};
+    HIP_ASSERT(hipMemcpy(scalar_tensor.data_, &test_val, sizeof(rocComplex), hipMemcpyHostToDevice));
+
+    status = rocquantum::util::rocTensorFree(&scalar_tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "alloc_free.scalar_free_status");
+
+    // Test zero-element tensor (e.g., one dim is 0)
+    rocquantum::util::rocTensor zero_el_tensor;
+    zero_el_tensor.dimensions_ = {2, 0, 2};
+    status = rocquantum::util::rocTensorAllocate(&zero_el_tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "alloc_free.zero_el_alloc_status");
+    ASSERT_EQ(zero_el_tensor.data_, nullptr, "alloc_free.zero_el_data_is_null");
+    ASSERT_TRUE(zero_el_tensor.owned_, "alloc_free.zero_el_owned"); // Owns "nothing"
+    ASSERT_EQ(zero_el_tensor.get_element_count(), 0, "alloc_free.zero_el_element_count");
+    status = rocquantum::util::rocTensorFree(&zero_el_tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "alloc_free.zero_el_free_status");
+
+
+    std::cout << "  Sub-test: rocTensorAllocate and rocTensorFree PASSED." << std::endl;
+    return true;
+}
+
+bool test_parse_simple_einsum_spec() {
+    std::cout << "  Sub-test: parse_simple_einsum_spec..." << std::endl;
+    rocquantum::util::rocTensor tensorA, tensorB; // Dummies for rank check
+    std::vector<std::pair<int, int>> contracted_pairs;
+    std::vector<int> res_A_modes, res_B_modes;
+    std::vector<long long> result_dims;
+    std::vector<std::string> result_labels;
+    bool parsed_ok;
+
+    // Matrix Multiply: A(ik),B(kj) -> C(ij)
+    tensorA.dimensions_ = {2, 3}; tensorA.labels_ = {"i", "k"}; // Actual labels not used by parser, only rank
+    tensorB.dimensions_ = {3, 4}; tensorB.labels_ = {"k", "j"};
+    std::string spec_mm = "ik,kj->ij";
+    parsed_ok = rocquantum::util::parse_simple_einsum_spec(spec_mm, &tensorA, &tensorB,
+                                            contracted_pairs, res_A_modes, res_B_modes,
+                                            result_dims, result_labels);
+    ASSERT_TRUE(parsed_ok, "einsum_parser.mm_parsed_ok");
+    ASSERT_EQ(contracted_pairs.size(), 1, "einsum_parser.mm_contracted_pairs_size");
+    if (!contracted_pairs.empty()) {
+        ASSERT_EQ(contracted_pairs[0].first, 1, "einsum_parser.mm_contracted_A_idx"); // k in A is mode 1
+        ASSERT_EQ(contracted_pairs[0].second, 0, "einsum_parser.mm_contracted_B_idx"); // k in B is mode 0
+    }
+    ASSERT_EQ(res_A_modes.size(), 1, "einsum_parser.mm_res_A_modes_size");
+    if(!res_A_modes.empty()) ASSERT_EQ(res_A_modes[0], 0, "einsum_parser.mm_res_A_mode0"); // i from A
+    ASSERT_EQ(res_B_modes.size(), 1, "einsum_parser.mm_res_B_modes_size");
+    if(!res_B_modes.empty()) ASSERT_EQ(res_B_modes[0], 1, "einsum_parser.mm_res_B_mode0"); // j from B
+    ASSERT_EQ(result_dims.size(), 2, "einsum_parser.mm_res_dims_size");
+    if (result_dims.size()==2) {
+        ASSERT_EQ(result_dims[0], 2, "einsum_parser.mm_res_dim0"); // dim of i
+        ASSERT_EQ(result_dims[1], 4, "einsum_parser.mm_res_dim1"); // dim of j
+    }
+    ASSERT_EQ(result_labels.size(), 2, "einsum_parser.mm_res_labels_size");
+     if (result_labels.size()==2) {
+        ASSERT_EQ(result_labels[0], "i", "einsum_parser.mm_res_label0");
+        ASSERT_EQ(result_labels[1], "j", "einsum_parser.mm_res_label1");
+    }
+
+    // Trace: A(ii)->
+    // Current parser requires output labels. A(ii)-> (scalar)
+    // For now, let's test A(ii)->s where 's' is a scalar label
+    contracted_pairs.clear(); res_A_modes.clear(); res_B_modes.clear(); result_dims.clear(); result_labels.clear();
+    tensorA.dimensions_ = {2, 2}; tensorA.labels_ = {"i", "i"};
+    tensorB.dimensions_ = {}; tensorB.labels_ = {}; // Not used for trace like this
+    std::string spec_trace = "ii,->s"; // Dummy B, A(ii)->s
+    // The parser expects two tensors for "LL,LL->LL".
+    // Let's adapt for how it might be used with rocTensorContractWithRocBLAS,
+    // which takes two tensors. A trace is typically A_ik * delta_ki.
+    // The current parser design isn't ideal for single tensor ops like trace if forced into "T1,T2->T3"
+    // Let's test "ii,->" (implicit scalar result from one tensor) - this will likely fail current parser.
+    // The parser expects labels for B. Let's try "ii,x->s" where x is a dummy label for a scalar B.
+    tensorA.dimensions_ = {2,2}; tensorA.labels_ = {"i","i"}; // A(ii)
+    tensorB.dimensions_ = {1}; tensorB.labels_ = {"x"};      // B(x) - a dummy scalar
+    spec_trace = "ii,x->s"; // This means sum over i, result is s, x is uncontracted from B.
+                            // This isn't a standard trace.
+                            // A real trace "ii->" would sum over 'i' and result in a scalar.
+                            // The parser might need "ii,->s" where "s" is explicitly the scalar output label.
+    // The parser's design `parse_simple_einsum_spec(spec, &tensorA, &tensorB, ...)` implies it always works on two tensors.
+    // A trace `Tr(M) = M_ii` needs a different parsing path or representation if done with one tensor.
+    // If we want to test "ii->s" (scalar output "s"), we need to check how the parser handles empty input for B.
+    // The current `comma_pos` check will fail if B's spec is empty.
+
+    // Test Outer Product: A(i),B(j) -> C(ij)
+    contracted_pairs.clear(); res_A_modes.clear(); res_B_modes.clear(); result_dims.clear(); result_labels.clear();
+    tensorA.dimensions_ = {2}; tensorA.labels_ = {"i"};
+    tensorB.dimensions_ = {3}; tensorB.labels_ = {"j"};
+    std::string spec_outer = "i,j->ij";
+    parsed_ok = rocquantum::util::parse_simple_einsum_spec(spec_outer, &tensorA, &tensorB,
+                                            contracted_pairs, res_A_modes, res_B_modes,
+                                            result_dims, result_labels);
+    ASSERT_TRUE(parsed_ok, "einsum_parser.outer_parsed_ok");
+    ASSERT_EQ(contracted_pairs.size(), 0, "einsum_parser.outer_contracted_size");
+    ASSERT_EQ(res_A_modes.size(), 1, "einsum_parser.outer_res_A_size");
+    if(!res_A_modes.empty()) ASSERT_EQ(res_A_modes[0], 0, "einsum_parser.outer_res_A_mode0");
+    ASSERT_EQ(res_B_modes.size(), 1, "einsum_parser.outer_res_B_size");
+    if(!res_B_modes.empty()) ASSERT_EQ(res_B_modes[0], 0, "einsum_parser.outer_res_B_mode0");
+    ASSERT_EQ(result_dims.size(), 2, "einsum_parser.outer_res_dims_size");
+    if(result_dims.size()==2) {
+        ASSERT_EQ(result_dims[0], 2, "einsum_parser.outer_res_dim0");
+        ASSERT_EQ(result_dims[1], 3, "einsum_parser.outer_res_dim1");
+    }
+
+    // Test with tensor names: TA(ik),TB(kj)->TC(ij)
+    spec_mm = "TA(ik),TB(kj)->TC(ij)";
+    parsed_ok = rocquantum::util::parse_simple_einsum_spec(spec_mm, &tensorA, &tensorB,
+                                            contracted_pairs, res_A_modes, res_B_modes,
+                                            result_dims, result_labels); // tensorA/B dims/labels are {2,3} {3,4}
+    ASSERT_TRUE(parsed_ok, "einsum_parser.mm_named_parsed_ok");
+    ASSERT_EQ(contracted_pairs.size(), 1, "einsum_parser.mm_named_contracted_pairs_size");
+     if (!contracted_pairs.empty()) {
+        ASSERT_EQ(contracted_pairs[0].first, 1, "einsum_parser.mm_named_contracted_A_idx");
+        ASSERT_EQ(contracted_pairs[0].second, 0, "einsum_parser.mm_named_contracted_B_idx");
+    }
+    ASSERT_EQ(result_dims.size(), 2, "einsum_parser.mm_named_res_dims_size");
+    if (result_dims.size()==2) {
+        ASSERT_EQ(result_dims[0], 2, "einsum_parser.mm_named_res_dim0");
+        ASSERT_EQ(result_dims[1], 4, "einsum_parser.mm_named_res_dim1");
+    }
+
+
+    // Test invalid: label count mismatch
+    tensorA.dimensions_ = {2,3}; tensorA.labels_ = {"i","k"};
+    tensorB.dimensions_ = {3,4}; tensorB.labels_ = {"k","j"};
+    std::string spec_invalid_labelcount = "ik,k->ij"; // B spec "k" is too short
+    parsed_ok = rocquantum::util::parse_simple_einsum_spec(spec_invalid_labelcount, &tensorA, &tensorB,
+                                            contracted_pairs, res_A_modes, res_B_modes,
+                                            result_dims, result_labels);
+    ASSERT_FALSE(parsed_ok, "einsum_parser.invalid_labelcount");
+
+    // Test invalid: dimension mismatch for contraction
+    tensorA.dimensions_ = {2,3}; tensorA.labels_ = {"i","k"}; // k is dim 3
+    tensorB.dimensions_ = {4,4}; tensorB.labels_ = {"k","j"}; // k is dim 4
+    std::string spec_invalid_dimmatch = "ik,kj->ij";
+    parsed_ok = rocquantum::util::parse_simple_einsum_spec(spec_invalid_dimmatch, &tensorA, &tensorB,
+                                            contracted_pairs, res_A_modes, res_B_modes,
+                                            result_dims, result_labels);
+    ASSERT_FALSE(parsed_ok, "einsum_parser.invalid_dimmatch");
+
+    // Test scalar result from full contraction: ab,ba->s
+    contracted_pairs.clear(); res_A_modes.clear(); res_B_modes.clear(); result_dims.clear(); result_labels.clear();
+    tensorA.dimensions_ = {2,3}; tensorA.labels_ = {"a","b"};
+    tensorB.dimensions_ = {3,2}; tensorB.labels_ = {"b","a"};
+    std::string spec_scalar_res = "ab,ba->s";
+     parsed_ok = rocquantum::util::parse_simple_einsum_spec(spec_scalar_res, &tensorA, &tensorB,
+                                            contracted_pairs, res_A_modes, res_B_modes,
+                                            result_dims, result_labels);
+    ASSERT_TRUE(parsed_ok, "einsum_parser.scalar_res_ok");
+    ASSERT_EQ(contracted_pairs.size(), 2, "einsum_parser.scalar_res_contract_count");
+    ASSERT_EQ(result_dims.size(), 1, "einsum_parser.scalar_res_dims_size");
+    if(!result_dims.empty()) ASSERT_EQ(result_dims[0], 1, "einsum_parser.scalar_res_dim_is_1");
+    ASSERT_EQ(result_labels.size(), 1, "einsum_parser.scalar_res_labels_size");
+    if(!result_labels.empty()) ASSERT_EQ(result_labels[0], "s", "einsum_parser.scalar_res_label_is_s");
+
+
+    std::cout << "  Sub-test: parse_simple_einsum_spec PASSED." << std::endl;
+    return true;
+}
+
+
+// More tests will follow for rocTensorPermute, rocTensorContractWithRocBLAS, WorkspaceManager, and TensorNetwork
+
+bool test_rocTensorPermute() {
+    std::cout << "  Sub-test: rocTensorPermute (matrix transpose)..." << std::endl;
+    rocquantum::util::rocTensor input_tensor, output_tensor;
+
+    // Input: 2x3 matrix
+    // 0 1 2
+    // 3 4 5
+    input_tensor.dimensions_ = {2, 3}; // M=2, N=3. Stored column-major: 0,3,1,4,2,5
+                                       // Stride for dim 0 is 1, stride for dim 1 is 2.
+                                       // (0,0)=0, (1,0)=3
+                                       // (0,1)=1, (1,1)=4
+                                       // (0,2)=2, (1,2)=5
+    input_tensor.calculate_strides();
+    std::vector<rocComplex> h_input_data = {
+        {0,0}, {3,0}, // col 0
+        {1,0}, {4,0}, // col 1
+        {2,0}, {5,0}  // col 2
+    };
+    rocqStatus_t status = rocquantum::util::rocTensorAllocate(&input_tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "permute.alloc_input");
+    HIP_ASSERT(hipMemcpy(input_tensor.data_, h_input_data.data(), h_input_data.size() * sizeof(rocComplex), hipMemcpyHostToDevice));
+
+    // Output: 3x2 matrix (transpose of input)
+    // 0 3
+    // 1 4
+    // 2 5
+    // Stored column-major: 0,1,2,3,4,5
+    output_tensor.dimensions_ = {3, 2}; // M=3, N=2
+    output_tensor.calculate_strides();
+     std::vector<rocComplex> h_expected_output_data = {
+        {0,0}, {1,0}, {2,0}, // col 0
+        {3,0}, {4,0}, {5,0}  // col 1
+    };
+    status = rocquantum::util::rocTensorAllocate(&output_tensor);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "permute.alloc_output");
+
+    // Permutation map: p[new_idx] = old_idx
+    // Input modes (old): {mode0_size2, mode1_size3}
+    // Output modes (new): {mode0_size3, mode1_size2}
+    // New mode 0 (size 3) was old mode 1.
+    // New mode 1 (size 2) was old mode 0.
+    // So, permutation_map = {1, 0}
+    std::vector<int> permutation_map = {1, 0};
+
+    status = rocquantum::util::rocTensorPermute(&output_tensor, &input_tensor, permutation_map);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "permute.rocTensorPermute_status");
+
+    HIP_ASSERT(hipStreamSynchronize(test_stream)); // Ensure kernel is done
+
+    std::vector<rocComplex> h_output_data(output_tensor.get_element_count());
+    HIP_ASSERT(hipMemcpy(h_output_data.data(), output_tensor.data_, h_output_data.size() * sizeof(rocComplex), hipMemcpyDeviceToHost));
+
+    ASSERT_EQ(h_output_data.size(), h_expected_output_data.size(), "permute.output_size_check");
+    for (size_t i = 0; i < h_expected_output_data.size(); ++i) {
+        ASSERT_COMPLEX_EQ(h_output_data[i], h_expected_output_data[i], "permute.output_data_element_" + std::to_string(i));
+    }
+
+    rocquantum::util::rocTensorFree(&input_tensor);
+    rocquantum::util::rocTensorFree(&output_tensor);
+    std::cout << "  Sub-test: rocTensorPermute (matrix transpose) PASSED." << std::endl;
+    return true;
+}
+
+bool test_rocTensorContractWithRocBLAS_matrix_multiply() {
+    std::cout << "  Sub-test: rocTensorContractWithRocBLAS (matrix multiply)..." << std::endl;
+    rocquantum::util::rocTensor tensorA, tensorB, tensorC_result;
+
+    // A (2x3)
+    //  1  2  3
+    //  4  5  6
+    // Column major host: 1,4, 2,5, 3,6
+    tensorA.dimensions_ = {2, 3}; // M=2, K=3
+    tensorA.labels_ = {"i", "k"};
+    tensorA.calculate_strides();
+    std::vector<rocComplex> h_A_data = {{1,0},{4,0}, {2,0},{5,0}, {3,0},{6,0}};
+    rocquantum::util::rocTensorAllocate(&tensorA);
+    HIP_ASSERT(hipMemcpy(tensorA.data_, h_A_data.data(), h_A_data.size() * sizeof(rocComplex), hipMemcpyHostToDevice));
+
+    // B (3x2)
+    //  7  8
+    //  9 10
+    // 11 12
+    // Column major host: 7,9,11, 8,10,12
+    tensorB.dimensions_ = {3, 2}; // K=3, N=2
+    tensorB.labels_ = {"k", "j"};
+    tensorB.calculate_strides();
+    std::vector<rocComplex> h_B_data = {{7,0},{9,0},{11,0}, {8,0},{10,0},{12,0}};
+    rocquantum::util::rocTensorAllocate(&tensorB);
+    HIP_ASSERT(hipMemcpy(tensorB.data_, h_B_data.data(), h_B_data.size() * sizeof(rocComplex), hipMemcpyHostToDevice));
+
+    // Expected C = A * B (2x2)
+    // C = [ (1*7 + 2*9 + 3*11)  (1*8 + 2*10 + 3*12) ]
+    //     [ (4*7 + 5*9 + 6*11)  (4*8 + 5*10 + 6*12) ]
+    //   = [ (7 + 18 + 33)  (8 + 20 + 36) ]
+    //     [ (28 + 45 + 66) (32 + 50 + 72) ]
+    //   = [ 58  64 ]
+    //     [ 139 154 ]
+    // Column major host: 58,139, 64,154
+    std::vector<rocComplex> h_C_expected = {{58,0},{139,0}, {64,0},{154,0}};
+    tensorC_result.dimensions_ = {2, 2}; // M=2, N=2
+    tensorC_result.labels_ = {"i", "j"}; // These will be set by parser if empty
+    tensorC_result.calculate_strides();
+    rocquantum::util::rocTensorAllocate(&tensorC_result);
+
+    const char* spec = "ik,kj->ij";
+    rocqStatus_t status = rocquantum::util::rocTensorContractWithRocBLAS(&tensorC_result, &tensorA, &tensorB, spec, blas_handle, test_stream);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "contract_mm.status_ok");
+    HIP_ASSERT(hipStreamSynchronize(test_stream));
+
+    ASSERT_COMPLEX_VEC_EQ(h_C_expected, tensorC_result.data_, h_C_expected.size(), "contract_mm.result_matches");
+
+    // Test with tensor names in spec
+    const char* spec_named = "A(ik),B(kj)->C(ij)";
+    // Need to reset tensorC_result or use a new one if its content is checked again
+    rocComplex zero = {0,0};
+    std::vector<rocComplex> h_C_zeros(tensorC_result.get_element_count(), zero);
+    HIP_ASSERT(hipMemcpy(tensorC_result.data_, h_C_zeros.data(), h_C_zeros.size() * sizeof(rocComplex), hipMemcpyHostToDevice));
+
+    status = rocquantum::util::rocTensorContractWithRocBLAS(&tensorC_result, &tensorA, &tensorB, spec_named, blas_handle, test_stream);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "contract_mm_named.status_ok");
+    HIP_ASSERT(hipStreamSynchronize(test_stream));
+    ASSERT_COMPLEX_VEC_EQ(h_C_expected, tensorC_result.data_, h_C_expected.size(), "contract_mm_named.result_matches");
+
+
+    rocquantum::util::rocTensorFree(&tensorA);
+    rocquantum::util::rocTensorFree(&tensorB);
+    rocquantum::util::rocTensorFree(&tensorC_result);
+    std::cout << "  Sub-test: rocTensorContractWithRocBLAS (matrix multiply) PASSED." << std::endl;
+    return true;
+}
+
+bool test_rocTensorContractWithRocBLAS_inner_product() {
+    std::cout << "  Sub-test: rocTensorContractWithRocBLAS (inner product)..." << std::endl;
+    rocquantum::util::rocTensor tensorA, tensorB, tensorC_result;
+
+    // A (vector of 3 elements)
+    tensorA.dimensions_ = {3};
+    tensorA.labels_ = {"i"};
+    tensorA.calculate_strides();
+    std::vector<rocComplex> h_A_data = {{1,1},{2,2},{3,3}}; // (1+i), (2+2i), (3+3i)
+    rocquantum::util::rocTensorAllocate(&tensorA);
+    HIP_ASSERT(hipMemcpy(tensorA.data_, h_A_data.data(), h_A_data.size() * sizeof(rocComplex), hipMemcpyHostToDevice));
+
+    // B (vector of 3 elements)
+    tensorB.dimensions_ = {3};
+    tensorB.labels_ = {"i"};
+    tensorB.calculate_strides();
+    std::vector<rocComplex> h_B_data = {{4,1},{5,1},{6,1}}; // (4+i), (5+i), (6+i)
+    rocquantum::util::rocTensorAllocate(&tensorB);
+    HIP_ASSERT(hipMemcpy(tensorB.data_, h_B_data.data(), h_B_data.size() * sizeof(rocComplex), hipMemcpyHostToDevice));
+
+    // Expected C = sum(A_i * B_i) (scalar)
+    // (1+i)(4+i) = 4 + i + 4i - 1 = 3 + 5i
+    // (2+2i)(5+i) = 10 + 2i + 10i - 2 = 8 + 12i
+    // (3+3i)(6+i) = 18 + 3i + 18i - 3 = 15 + 21i
+    // Sum = (3+8+15) + (5+12+21)i = 26 + 38i
+    std::vector<rocComplex> h_C_expected = {{26,38}};
+
+    // Result tensor (scalar)
+    // The parser "i,i->s" will make result_dims {1}
+    tensorC_result.dimensions_ = {1};
+    tensorC_result.labels_ = {"s"}; // Placeholder, parser will set based on spec
+    tensorC_result.calculate_strides(); // Strides will be {1}
+    rocquantum::util::rocTensorAllocate(&tensorC_result);
+
+    // Spec for inner product (sum over 'i', result is scalar 's')
+    const char* spec = "i,i->s";
+    rocqStatus_t status = rocquantum::util::rocTensorContractWithRocBLAS(&tensorC_result, &tensorA, &tensorB, spec, blas_handle, test_stream);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "contract_inner_prod.status_ok");
+    HIP_ASSERT(hipStreamSynchronize(test_stream));
+
+    ASSERT_COMPLEX_VEC_EQ(h_C_expected, tensorC_result.data_, h_C_expected.size(), "contract_inner_prod.result_matches");
+
+    rocquantum::util::rocTensorFree(&tensorA);
+    rocquantum::util::rocTensorFree(&tensorB);
+    rocquantum::util::rocTensorFree(&tensorC_result);
+    std::cout << "  Sub-test: rocTensorContractWithRocBLAS (inner product) PASSED." << std::endl;
+    return true;
+}
+
+bool test_rocWorkspaceManager_basic() {
+    std::cout << "  Sub-test: rocWorkspaceManager basic operations..." << std::endl;
+
+    size_t num_complex_elements_total = 1024;
+    size_t workspace_size_bytes = num_complex_elements_total * sizeof(rocComplex); // 1024 rocComplex elements
+
+    rocquantum::util::WorkspaceManager ws_manager(workspace_size_bytes, test_stream);
+    ASSERT_EQ(ws_manager.get_total_size_bytes(), workspace_size_bytes, "ws_manager.total_size_init");
+    ASSERT_EQ(ws_manager.get_used_size_bytes(), 0, "ws_manager.used_size_init");
+
+    // Allocate a small chunk
+    size_t alloc1_elements = 10;
+    rocComplex* ptr1 = ws_manager.allocate(alloc1_elements);
+    ASSERT_TRUE(ptr1 != nullptr, "ws_manager.alloc1_ptr_not_null");
+    // Used size should be alloc1_elements * sizeof(rocComplex), potentially aligned
+    size_t expected_used1 = alloc1_elements * sizeof(rocComplex);
+    if ((expected_used1 % 256) != 0) expected_used1 = ((expected_used1 + 256 -1) / 256) * 256; // Assuming 256 alignment
+    // The get_used_size_bytes returns the *next* aligned offset, so it reflects usage *after* alignment for the *next* allocation.
+    // If current_offset_bytes_ is used directly, it would be alloc1_elements * sizeof(rocComplex).
+    // The current implementation of get_used_size_bytes returns the aligned offset.
+    // Let's check current_offset_bytes_ for precise usage before next alignment.
+    // This requires exposing current_offset_bytes or making get_used_size_bytes return raw offset.
+    // For now, let's test based on observed behavior of get_used_size_bytes (next aligned offset).
+    // If an allocation exactly fits an alignment boundary, get_used_size_bytes() would be that boundary.
+    // If it's less, get_used_size_bytes() will be the end of the current allocation.
+    // The `WorkspaceManager::allocate` updates `current_offset_bytes_` to `aligned_offset + requested_bytes;`
+    // `get_used_size_bytes` returns `current_offset_bytes_` after potential alignment for the *next* allocation.
+    // So, if alloc1_elements * sizeof(rocComplex) is, say, 80 bytes, and alignment is 256,
+    // current_offset_bytes_ becomes 80. get_used_size_bytes() would return 256.
+    // This is a bit confusing. Let's assume get_used_size_bytes() is the actual end of data.
+    // The WorkspaceManager code: `current_offset_bytes_ = aligned_offset + requested_bytes;`
+    // `get_used_size_bytes()`: `aligned_offset = current_offset_bytes_; if (current_offset_bytes_ % alignment_ !=0) ...; return aligned_offset;`
+    // This means `get_used_size_bytes()` is the *start* of the *next* allocation.
+    // So if `current_offset_bytes_` is 80, `get_used_size_bytes()` would be 256 (if alignment is 256).
+    // This is fine, it tells us how much is "reserved".
+
+    size_t actual_used_after_alloc1 = ws_manager.get_used_size_bytes();
+    size_t raw_bytes1 = alloc1_elements * sizeof(rocComplex);
+    size_t expected_aligned_offset1 = ((0 + 256 -1) / 256) * 256; // Start is 0
+    size_t expected_current_offset1 = expected_aligned_offset1 + raw_bytes1;
+
+    // ASSERT_EQ(actual_used_after_alloc1, expected_current_offset1_aligned_for_next, "ws_manager.used_size_alloc1");
+    // Let's simplify: just check it increased, and allocations don't overlap.
+    ASSERT_TRUE(actual_used_after_alloc1 >= raw_bytes1, "ws_manager.used_size_alloc1_increased");
+
+
+    // Allocate another chunk
+    size_t alloc2_elements = 20;
+    rocComplex* ptr2 = ws_manager.allocate(alloc2_elements);
+    ASSERT_TRUE(ptr2 != nullptr, "ws_manager.alloc2_ptr_not_null");
+    ASSERT_TRUE(ptr2 != ptr1, "ws_manager.alloc2_ptr_different_from_ptr1");
+    // Check for non-overlap: ptr2 should be at least ptr1 + size_of_alloc1 (with alignment)
+    char* char_ptr1 = reinterpret_cast<char*>(ptr1);
+    char* char_ptr2 = reinterpret_cast<char*>(ptr2);
+    size_t min_distance = (alloc1_elements * sizeof(rocComplex) + 256 -1 ) / 256 * 256; //aligned end of ptr1
+    // ASSERT_TRUE( (size_t)(char_ptr2 - char_ptr1) >= alloc1_elements * sizeof(rocComplex), "ws_manager.ptr2_after_ptr1");
+    // This check is tricky due to alignment. Simpler: ptr2 should be > ptr1 if alloc1_elements > 0
+    if (alloc1_elements > 0) {
+      ASSERT_TRUE(ptr2 > ptr1, "ws_manager.ptr2_strictly_after_ptr1");
+    }
+    size_t actual_used_after_alloc2 = ws_manager.get_used_size_bytes();
+    ASSERT_TRUE(actual_used_after_alloc2 > actual_used_after_alloc1 || alloc2_elements == 0, "ws_manager.used_size_alloc2_increased");
+
+
+    // Test allocation that should fail (too large)
+    size_t alloc3_elements = num_complex_elements_total; // Try to allocate the whole workspace again
+    rocComplex* ptr3 = ws_manager.allocate(alloc3_elements);
+    ASSERT_TRUE(ptr3 == nullptr, "ws_manager.alloc3_ptr_is_null_for_too_large");
+
+    // Test reset
+    ws_manager.reset();
+    ASSERT_EQ(ws_manager.get_used_size_bytes(), 0, "ws_manager.used_size_after_reset");
+
+    // Allocate again after reset
+    rocComplex* ptr4 = ws_manager.allocate(alloc1_elements);
+    ASSERT_TRUE(ptr4 != nullptr, "ws_manager.alloc4_ptr_not_null_after_reset");
+    // Pointer after reset should ideally be the same as the first pointer, if simple bump allocator
+    ASSERT_EQ(ptr4, ptr1, "ws_manager.alloc4_ptr_same_as_ptr1_after_reset");
+
+    // Allocate exactly remaining space
+    ws_manager.reset();
+    size_t remaining_elements = num_complex_elements_total;
+    // Account for initial alignment of the very first block
+    size_t initial_padding = 0; // current_offset_bytes_ is 0, alignment is 256. aligned_offset will be 0.
+
+    rocComplex* ptr5 = ws_manager.allocate(remaining_elements);
+    ASSERT_TRUE(ptr5 != nullptr, "ws_manager.alloc_full_workspace");
+
+    rocComplex* ptr6 = ws_manager.allocate(1); // Should fail now
+    ASSERT_TRUE(ptr6 == nullptr, "ws_manager.alloc_should_fail_when_full");
+
+    // Test with zero initial size
+    bool constructor_threw = false;
+    try {
+        rocquantum::util::WorkspaceManager ws_zero(0, test_stream);
+        rocComplex* p_zero = ws_zero.allocate(1); // Should be nullptr
+        ASSERT_TRUE(p_zero == nullptr, "ws_manager.alloc_from_zero_size_ws_is_null");
+        ASSERT_EQ(ws_zero.get_total_size_bytes(), 0, "ws_manager.zero_total_size");
+    } catch (const std::runtime_error& e) {
+        // Constructor throwing for size 0 if hipMalloc fails for 0 is also acceptable
+        // but current hipMalloc(0) might return nullptr or a unique ptr.
+        // The WorkspaceManager itself doesn't throw for size 0, but hipMalloc might.
+        // Current hipMalloc(0) behavior is often to return a valid pointer that can be passed to hipFree.
+        // The WorkspaceManager code has `if (total_size_bytes_ > 0)` for `hipMalloc`.
+        // So for 0, `d_workspace_ptr_` remains `nullptr`.
+    }
+
+
+    std::cout << "  Sub-test: rocWorkspaceManager basic operations PASSED." << std::endl;
+    return true;
+}
+
+
+// Helper function to create a rocTensor with data on GPU
+rocquantum::util::rocTensor create_gpu_tensor(const std::vector<long long>& dims, const std::vector<std::string>& labels, const std::vector<rocComplex>& h_data) {
+    rocquantum::util::rocTensor tensor;
+    tensor.dimensions_ = dims;
+    tensor.labels_ = labels;
+    tensor.calculate_strides();
+    rocquantum::util::rocTensorAllocate(&tensor);
+    HIP_ASSERT(hipMemcpy(tensor.data_, h_data.data(), h_data.size() * sizeof(rocComplex), hipMemcpyHostToDevice));
+    return tensor; // Returns a rocTensor struct (potentially moves if RVO applies)
+                  // The data is owned by this tensor instance due to rocTensorAllocate
+}
+
+bool test_TensorNetwork_contract_simple_chain_internal(bool use_external_workspace) {
+    std::cout << "  Sub-test: TensorNetwork contract simple chain (use_external_workspace=" << use_external_workspace << ")..." << std::endl;
+
+    // Network: A(a,b) * B(b,c) * C(c,d) -> Result(a,d)
+    // Dimensions: a=2, b=3, c=4, d=2
+    // A(2,3), B(3,4), C(4,2) -> Result(2,2)
+
+    std::vector<rocComplex> h_A_data(2*3); // A(a,b)
+    for(int i=0; i<6; ++i) h_A_data[i] = {(float)i+1, 0};
+    // A col-major: (1,0) (4,0)
+    //              (2,0) (5,0)
+    //              (3,0) (6,0)
+    // A data: {1,2,3,4,5,6} if we fill it row-by-row for conceptual matrix
+    // (0,0)=1 (0,1)=2 (0,2)=3
+    // (1,0)=4 (1,1)=5 (1,2)=6
+    // Stored as: {1,4,2,5,3,6}
+    std::vector<rocComplex> h_A_colmajor = {{1,0},{4,0}, {2,0},{5,0}, {3,0},{6,0}};
+
+
+    std::vector<rocComplex> h_B_data(3*4); // B(b,c)
+    for(int i=0; i<12; ++i) h_B_data[i] = {(float)i+0.5f, 0};
+    // B col-major: (0.5,0) (3.5,0) (6.5,0) (9.5,0)
+    //              (1.5,0) (4.5,0) (7.5,0) (10.5,0)
+    //              (2.5,0) (5.5,0) (8.5,0) (11.5,0)
+    // B data: {0.5, 1.5, 2.5, ...}
+    std::vector<rocComplex> h_B_colmajor(12);
+    for(int j=0; j<4; ++j) { // cols
+        for(int i=0; i<3; ++i) { // rows
+            h_B_colmajor[i + j*3] = {(float)(i + j*3 + 0.5f), 0};
+        }
+    }
+
+
+    std::vector<rocComplex> h_C_data(4*2); // C(c,d)
+    for(int i=0; i<8; ++i) h_C_data[i] = {(float)i+0.2f, 0};
+    // C data: {0.2, 1.2, 2.2, ...}
+    std::vector<rocComplex> h_C_colmajor(8);
+     for(int j=0; j<2; ++j) { // cols
+        for(int i=0; i<4; ++i) { // rows
+            h_C_colmajor[i + j*4] = {(float)(i + j*4 + 0.2f), 0};
+        }
+    }
+
+    rocquantum::util::rocTensor tensorA = create_gpu_tensor({2,3}, {"a","b"}, h_A_colmajor);
+    rocquantum::util::rocTensor tensorB = create_gpu_tensor({3,4}, {"b","c"}, h_B_colmajor);
+    rocquantum::util::rocTensor tensorC = create_gpu_tensor({4,2}, {"c","d"}, h_C_colmajor);
+
+    rocquantum::util::WorkspaceManager* ext_ws = nullptr;
+    if (use_external_workspace) {
+        ext_ws = new rocquantum::util::WorkspaceManager(1024 * 1024 * 8, test_stream); // 8MB workspace
+    }
+
+    rocquantum::TensorNetwork tn(ext_ws, test_stream); // Pass stream if constructor takes it
+    tn.add_tensor(tensorA); // tensorA is copied by value (metadata), data is view
+    tn.add_tensor(tensorB);
+    tn.add_tensor(tensorC);
+
+    rocquantum::util::rocTensor result_tensor_gpu;
+    rocqStatus_t status = tn.contract(&result_tensor_gpu, blas_handle, test_stream);
+    ASSERT_EQ(status, ROCQ_STATUS_SUCCESS, "tn_chain.contract_status");
+    HIP_ASSERT(hipStreamSynchronize(test_stream));
+
+    // Expected result: (A*B)*C
+    // A(2x3), B(3x4) -> AB(2x4)
+    // AB(2x4) * C(4x2) -> Result(2x2)
+
+    // Calculate expected AB = A*B manually (or using rocBLAS for this sub-part if complex)
+    // A = [[1,2,3], [4,5,6]]   B = [[0.5, 3.5, 6.5, 9.5], [1.5, 4.5, 7.5, 10.5], [2.5, 5.5, 8.5, 11.5]]
+    // AB_00 = 1*0.5 + 2*1.5 + 3*2.5 = 0.5 + 3 + 7.5 = 11
+    // AB_01 = 1*3.5 + 2*4.5 + 3*5.5 = 3.5 + 9 + 16.5 = 29
+    // AB_02 = 1*6.5 + 2*7.5 + 3*8.5 = 6.5 + 15 + 25.5 = 47
+    // AB_03 = 1*9.5 + 2*10.5 + 3*11.5 = 9.5 + 21 + 34.5 = 65
+    // AB_10 = 4*0.5 + 5*1.5 + 6*2.5 = 2 + 7.5 + 15 = 24.5
+    // AB_11 = 4*3.5 + 5*4.5 + 6*5.5 = 14 + 22.5 + 33 = 69.5
+    // AB_12 = 4*6.5 + 5*7.5 + 6*8.5 = 26 + 37.5 + 51 = 114.5
+    // AB_13 = 4*9.5 + 5*10.5 + 6*11.5 = 38 + 52.5 + 69 = 159.5
+    // AB = [[11, 29, 47, 65], [24.5, 69.5, 114.5, 159.5]] (2x4)
+
+    // C = [[0.2, 4.2], [1.2, 5.2], [2.2, 6.2], [3.2, 7.2]]
+    // Result = AB * C
+    // Res_00 = 11*0.2 + 29*1.2 + 47*2.2 + 65*3.2 = 2.2 + 34.8 + 103.4 + 208 = 348.4
+    // Res_01 = 11*4.2 + 29*5.2 + 47*6.2 + 65*7.2 = 46.2 + 150.8 + 291.4 + 468 = 956.4
+    // Res_10 = 24.5*0.2 + 69.5*1.2 + 114.5*2.2 + 159.5*3.2 = 4.9 + 83.4 + 251.9 + 510.4 = 850.6
+    // Res_11 = 24.5*4.2 + 69.5*5.2 + 114.5*6.2 + 159.5*7.2 = 102.9 + 361.4 + 710 + 1148.4 = 2322.6 // Error in manual calculation somewhere, recheck.
+    // Let's use a simpler data set for manual check or trust the component tests for rocTensorContract.
+    // For this test, focus on path and memory. If component contract test passes, this should be fine if path is right.
+
+    // Path taken: (A*B)*C or A*(B*C). Greedy chooses based on intermediate size.
+    // A(2,3) B(3,4) -> AB(2,4) size 8. Contracted K=3.
+    // B(3,4) C(4,2) -> BC(3,2) size 6. Contracted K=4.
+    // Greedy should choose (B*C) first. So order is A*(B*C).
+    // Intermediate BC(b,d) with dims {3,2}.
+    // Then A(a,b) * BC(b,d) -> Result(a,d) dims {2,2}.
+
+    // B*C:
+    // B (3x4), C(4x2) -> BC(3x2)
+    // B= [[0.5, 3.5,  6.5,  9.5 ],
+    //     [1.5, 4.5,  7.5,  10.5],
+    //     [2.5, 5.5,  8.5,  11.5]]
+    // C= [[0.2, 4.2],
+    //     [1.2, 5.2],
+    //     [2.2, 6.2],
+    //     [3.2, 7.2]]
+    // BC_00 = 0.5*0.2 + 3.5*1.2 + 6.5*2.2 + 9.5*3.2 = 0.1 + 4.2 + 14.3 + 30.4 = 49
+    // BC_01 = 0.5*4.2 + 3.5*5.2 + 6.5*6.2 + 9.5*7.2 = 2.1 + 18.2 + 40.3 + 68.4 = 129
+    // BC_10 = 1.5*0.2 + 4.5*1.2 + 7.5*2.2 + 10.5*3.2 = 0.3 + 5.4 + 16.5 + 33.6 = 55.8
+    // BC_11 = 1.5*4.2 + 4.5*5.2 + 7.5*6.2 + 10.5*7.2 = 6.3 + 23.4 + 46.5 + 75.6 = 151.8
+    // BC_20 = 2.5*0.2 + 5.5*1.2 + 8.5*2.2 + 11.5*3.2 = 0.5 + 6.6 + 18.7 + 36.8 = 62.6
+    // BC_21 = 2.5*4.2 + 5.5*5.2 + 8.5*6.2 + 11.5*7.2 = 10.5 + 28.6 + 52.7 + 82.8 = 174.6
+    // BC = [[49, 129], [55.8, 151.8], [62.6, 174.6]] (3x2) (labels b,d)
+
+    // A * BC:
+    // A (2x3), BC(3x2) -> Res(2x2)
+    // A = [[1,2,3], [4,5,6]]
+    // Res_00 = 1*49 + 2*55.8 + 3*62.6 = 49 + 111.6 + 187.8 = 348.4
+    // Res_01 = 1*129 + 2*151.8 + 3*174.6 = 129 + 303.6 + 523.8 = 956.4
+    // Res_10 = 4*49 + 5*55.8 + 6*62.6 = 196 + 279 + 375.6 = 850.6
+    // Res_11 = 4*129 + 5*151.8 + 6*174.6 = 516 + 759 + 1047.6 = 2322.6
+    // Expected Result(a,d) = [[348.4, 956.4], [850.6, 2322.6]]
+    // Column major: {348.4, 850.6, 956.4, 2322.6}
+    std::vector<rocComplex> h_Res_expected = {{348.4f,0}, {850.6f,0}, {956.4f,0}, {2322.6f,0}};
+
+    ASSERT_EQ(result_tensor_gpu.rank(), 2, "tn_chain.result_rank");
+    if(result_tensor_gpu.rank() == 2) {
+        ASSERT_EQ(result_tensor_gpu.dimensions_[0], 2, "tn_chain.result_dim0");
+        ASSERT_EQ(result_tensor_gpu.dimensions_[1], 2, "tn_chain.result_dim1");
+    }
+    ASSERT_EQ(result_tensor_gpu.get_element_count(), 4, "tn_chain.result_element_count");
+    if (result_tensor_gpu.data_ && result_tensor_gpu.get_element_count() == 4) {
+         ASSERT_COMPLEX_VEC_EQ(h_Res_expected, result_tensor_gpu.data_, h_Res_expected.size(), "tn_chain.result_data");
+    } else {
+        ASSERT_TRUE(false, "tn_chain.result_data_not_checked_due_to_null_or_size_mismatch");
+    }
+
+
+    // Cleanup
+    rocquantum::util::rocTensorFree(&tensorA); // Frees data because it was created with create_gpu_tensor -> rocTensorAllocate
+    rocquantum::util::rocTensorFree(&tensorB);
+    rocquantum::util::rocTensorFree(&tensorC);
+    rocquantum::util::rocTensorFree(&result_tensor_gpu); // Result tensor from contract is also owned and needs free
+
+    if (ext_ws) {
+        delete ext_ws;
+    }
+
+    std::cout << "  Sub-test: TensorNetwork contract simple chain (use_external_workspace=" << use_external_workspace << ") PASSED." << std::endl;
+    return true;
+}
+
+bool test_TensorNetwork_contract_simple_chain() {
+    bool internal_ws_ok = test_TensorNetwork_contract_simple_chain_internal(false);
+    bool external_ws_ok = test_TensorNetwork_contract_simple_chain_internal(true);
+    return internal_ws_ok && external_ws_ok;
+}
+
+
+int main() {
+    setup_global_test_resources();
+
+    ADD_TEST(test_rocTensor_struct);
+    ADD_TEST(test_rocTensor_alloc_free);
+    ADD_TEST(test_parse_simple_einsum_spec);
+    // ADD_TEST(test_rocTensorPermute);
+    ADD_TEST(test_rocTensorPermute);
+    ADD_TEST(test_rocTensorContractWithRocBLAS_matrix_multiply);
+    ADD_TEST(test_rocTensorContractWithRocBLAS_inner_product);
+    ADD_TEST(test_rocWorkspaceManager_basic);
+    ADD_TEST(test_TensorNetwork_contract_simple_chain);
+
+    RUN_ALL_TESTS();
+
+    teardown_global_test_resources();
+    return 0;
+}
+
+// Placeholder for rocquantum::checkHipError if not found in hipStateVec.h
+// For now, assume it's available or tests will fail to link/run if it's critical.
+// If hipStateVec.h only declares it, and it's defined in hipStateVec.cpp,
+// we might need to link against that object file or provide a minimal version here.
+// For now, the HIP_ASSERT macro handles errors locally.
+namespace rocquantum {
+    // Minimal version if not linked
+    rocqStatus_t checkHipError(hipError_t err, const char* message) {
+        if (err != hipSuccess) {
+            // std::cerr << "HIP Error (" << message << "): " << hipGetErrorString(err) << std::endl;
+            return ROCQ_STATUS_HIP_ERROR;
+        }
+        return ROCQ_STATUS_SUCCESS;
+    }
+}


### PR DESCRIPTION
….1 scaffolding

- Added unit tests for hipTensorNet and rocTensorUtil components.
- Refactored hipStateVec to support selectable precision (float/double) via ROCQ_PRECISION_DOUBLE macro.
- Updated hipStateVec generic single-qubit gate kernel to use constant memory for the matrix.
- Implemented initial Python API scaffolding for rocHybrid v0.1, including:
  - PauliOperator class.
  - @rocq.kernel decorator and rocq.build() (simple dispatcher model).
  - rocq.get_expval() supporting identity and single Pauli Z terms.
- Added rocsvGetExpectationValueSinglePauliZ C-API function to hipStateVec for calculating <Z_k> and its Python binding.
- Created a basic VQE example script (examples/run_simple_vqe.py) using the new rocHybrid scaffolding and targeting hipStateVec.