### PR TITLE
feat: Expectation values, MLIR string gen, hipTensorNet parser, hipSt…

### DIFF
--- a/rocquantum/include/rocquantum/Compiler/MLIRCompiler.h
+++ b/rocquantum/include/rocquantum/Compiler/MLIRCompiler.h
@@ -1,0 +1,77 @@
+#ifndef ROCQUANTUM_MLIRCOMPILER_H
+#define ROCQUANTUM_MLIRCOMPILER_H
+
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/BuiltinOps.h" // For ModuleOp
+#include "mlir/Dialect/Func/IR/FuncOps.h" // For FuncOp and FunctionType
+#include "mlir/IR/OwningOpRef.h"
+#include "rocquantum/Dialect/QuantumDialect.h" // Include our QuantumDialect
+
+#include <string>
+#include <memory> // For std::unique_ptr
+#include "llvm/ADT/SmallVector.h" // For TypeRange (mlir::TypeRange is often an alias to this)
+
+
+namespace rocquantum {
+namespace compiler {
+
+class MLIRCompiler {
+public:
+    MLIRCompiler();
+    ~MLIRCompiler();
+
+    // Initializes a new MLIR module. Returns true on success.
+    // The module will be owned by this MLIRCompiler instance.
+    bool initializeModule(const std::string& moduleName = "rocq_module");
+
+    // Dumps the current module to stderr (for debugging).
+    void dumpModule() const;
+
+    // Gets the current module as a string.
+    std::string getModuleString() const;
+
+    // Parses an MLIR string and loads it into the current module.
+    // Returns true on success, false on parsing error.
+    // This will replace the current module if one exists.
+    bool loadModuleFromString(const std::string& mlirString);
+
+    // Gets a pointer to the MLIRContext (non-owning).
+    // Caution: Lifetime is tied to MLIRCompiler instance.
+    mlir::MLIRContext* getContext();
+
+    // Gets a pointer to the ModuleOp (non-owning).
+    // Caution: Lifetime is tied to MLIRCompiler instance and its OwningOpRef.
+    mlir::ModuleOp getModule() const;
+
+    // Creates a new mlir::func::FuncOp within the current module.
+    // Returns the created FuncOp (non-owning, valid as long as module_ is valid).
+    // The argument types are MLIR types (e.g., from QubitType::get(context)).
+    // Returns an empty FuncOp (evaluates to false in boolean context) on failure.
+    mlir::func::FuncOp createFunction(const std::string& funcName,
+                                      mlir::TypeRange argTypes,
+                                      mlir::TypeRange resultTypes = {});
+
+    // Adds a generic quantum gate to the last block of the given function.
+    // Qubit values are passed as block arguments to the function.
+    // Returns success if the op was added.
+    mlir::LogicalResult addGenericGateOp(mlir::func::FuncOp funcOp,
+                                         const std::string& gateName,
+                                         mlir::ValueRange qubitOperands,
+                                         const std::vector<double>& params = {}); // For parameterized gates
+
+
+    // MLIRCompiler is non-copyable, non-movable for simplicity with OwningOpRef
+    MLIRCompiler(const MLIRCompiler&) = delete;
+    MLIRCompiler& operator=(const MLIRCompiler&) = delete;
+    MLIRCompiler(MLIRCompiler&&) = delete;
+    MLIRCompiler& operator=(MLIRCompiler&&) = delete;
+
+private:
+    std::unique_ptr<mlir::MLIRContext> context_;
+    mlir::OwningOpRef<mlir::ModuleOp> module_; // Owning reference to the top-level module
+};
+
+} // namespace compiler
+} // namespace rocquantum
+
+#endif // ROCQUANTUM_MLIRCOMPILER_H

--- a/rocquantum/include/rocquantum/hipStateVec.h
+++ b/rocquantum/include/rocquantum/hipStateVec.h
@@ -246,6 +246,37 @@ rocqStatus_t rocsvApplyCZ(rocsvHandle_t handle, rocComplex* d_state, unsigned nu
  */
 rocqStatus_t rocsvApplySWAP(rocsvHandle_t handle, rocComplex* d_state, unsigned numQubits, unsigned qubit1, unsigned qubit2);
 
+// --- Pinned Memory Management ---
+/**
+ * @brief Ensures a pinned host buffer of at least `minSizeBytes` is allocated within the handle.
+ * If a buffer exists but is smaller, it's reallocated. If it's already large enough, it's reused.
+ * The pointer to the pinned buffer can be retrieved using `rocsvGetPinnedBufferPointer`.
+ * This buffer is intended for efficient asynchronous host-to-device or device-to-host transfers.
+ *
+ * @param[in] handle The hipStateVec handle.
+ * @param[in] minSizeBytes The minimum required size of the pinned buffer in bytes.
+ * @return rocqStatus_t Status of the operation.
+ */
+rocqStatus_t rocsvEnsurePinnedBuffer(rocsvHandle_t handle, size_t minSizeBytes);
+
+/**
+ * @brief Retrieves a pointer to the internally managed pinned host buffer.
+ * Call `rocsvEnsurePinnedBuffer` first to make sure it's allocated to a sufficient size.
+ *
+ * @param[in] handle The hipStateVec handle.
+ * @return void* Pointer to the pinned host buffer, or nullptr if not allocated or handle is invalid.
+ */
+void* rocsvGetPinnedBufferPointer(rocsvHandle_t handle);
+
+/**
+ * @brief Frees the internally managed pinned host buffer.
+ *
+ * @param[in] handle The hipStateVec handle.
+ * @return rocqStatus_t Status of the operation.
+ */
+rocqStatus_t rocsvFreePinnedBuffer(rocsvHandle_t handle);
+
+
 /**
  * @brief Calculates the expectation value of a single Pauli Z operator on a target qubit.
  * <psi|Z_k|psi> = P(k=0) - P(k=1)
@@ -300,6 +331,26 @@ rocqStatus_t rocsvGetExpectationValueSinglePauliY(rocsvHandle_t handle,
                                                   unsigned numQubits,
                                                   unsigned targetQubit,
                                                   double* result);
+
+/**
+ * @brief Calculates the expectation value of a product of Pauli Z operators.
+ * <psi|Z_q0 Z_q1 ... Z_qn|psi>
+ * Note: This function does NOT modify the state vector.
+ *
+ * @param[in] handle The hipStateVec handle.
+ * @param[in] d_state Pointer to the device state vector. (See notes in rocsvGetExpectationValueSinglePauliZ)
+ * @param[in] numQubits Total number of qubits.
+ * @param[in] targetQubits Array of global qubit indices for the Z operators.
+ * @param[in] numTargetPaulis Number of Pauli Z operators in the product (length of targetQubits array).
+ * @param[out] result Pointer to store the expectation value.
+ * @return rocqStatus_t Status.
+ */
+rocqStatus_t rocsvGetExpectationValuePauliProductZ(rocsvHandle_t handle,
+                                                   rocComplex* d_state,
+                                                   unsigned numQubits,
+                                                   const unsigned* targetQubits,
+                                                   unsigned numTargetPaulis,
+                                                   double* result);
 
 
 #ifdef __cplusplus

--- a/rocquantum/src/hipStateVec/measurement_kernels.hip
+++ b/rocquantum/src/hipStateVec/measurement_kernels.hip
@@ -276,3 +276,112 @@ __global__ void reduce_block_sums_to_slice_total_sum_sq_mag_kernel(
         d_slice_total_sum_sq_mag_out[0] = s_reduce_sum_sq[0];
     }
 }
+
+// Kernel to calculate probabilities for 2^k outcomes of k target Z measurements.
+// Output: d_outcome_probs_blocks - an array where each block writes its 2^k partial probability sums.
+// The size of d_outcome_probs_blocks should be gridDim.x * (1 << num_target_paulis).
+__global__ void calculate_multi_z_probabilities_kernel(
+    const rocComplex* local_slice_data,
+    size_t local_slice_num_elements,
+    unsigned num_local_qubits,         // Total qubits in this slice/state_vector
+    const unsigned* d_target_qubits,   // Device array of target qubit indices (local to slice)
+    unsigned num_target_paulis,        // Number of Z paulistrings in the product (k)
+    real_t* d_outcome_probs_blocks) {  // Output for block-level sums
+
+    unsigned int KERNEL_MAX_TARGET_PAULIS = 8; // Max k for this kernel (2^8=256 outcomes)
+                                              // Adjust based on shared memory limits / complexity.
+                                              // For >8, might need different strategy or multiple passes.
+    if (num_target_paulis == 0 || num_target_paulis > KERNEL_MAX_TARGET_PAULIS) {
+        // Or handle error, assert, etc. For now, just return if invalid.
+        // If num_target_paulis is 0, result is just total sum of squares (norm), which is 1.0.
+        // The calling C++ function should handle num_target_paulis = 0 separately.
+        return;
+    }
+
+    unsigned num_outcomes = 1 << num_target_paulis; // 2^k
+
+    // Shared memory for per-block reduction of 2^k probabilities
+    // Max size: 256 * sizeof(real_t) for KERNEL_MAX_TARGET_PAULIS = 8
+    extern __shared__ real_t s_prob_bins[]; // Size should be blockDim.x * num_outcomes if each thread had its own bins
+                                         // Or just num_outcomes if we reduce carefully.
+                                         // Let's use num_outcomes and atomicAdd or careful per-thread accumulation.
+                                         // For a warp-level or block-level reduction, size is num_outcomes.
+
+    unsigned int tid_in_block = threadIdx.x;
+
+    // Initialize shared memory for this block
+    if (tid_in_block < num_outcomes) {
+        s_prob_bins[tid_in_block] = 0.0;
+    }
+    __syncthreads();
+
+    size_t global_idx_start = blockIdx.x * blockDim.x;
+
+    // Each thread iterates over its assigned elements from the slice
+    for (size_t i = tid_in_block; i < blockDim.x; i += blockDim.x) { // This loop over elements within a block's responsibility
+        size_t current_local_idx = global_idx_start + i;
+        if (current_local_idx < local_slice_num_elements) {
+            rocComplex amp = local_slice_data[current_local_idx];
+            real_t mag_sq = (real_t)amp.x * amp.x + (real_t)amp.y * amp.y;
+
+            // Determine the outcome bin for this amplitude
+            unsigned outcome_bin_idx = 0;
+            for (unsigned pauli_k = 0; pauli_k < num_target_paulis; ++pauli_k) {
+                unsigned target_q_idx = d_target_qubits[pauli_k]; // Qubit index for the k-th Pauli Z
+                if (((current_local_idx >> target_q_idx) & 1)) { // If this qubit is 1 for current amplitude
+                    outcome_bin_idx |= (1 << pauli_k); // Set the k-th bit in the outcome bin index
+                }
+            }
+            // Atomically add to the correct bin in shared memory
+            // This is okay for up to ~32-64 bins if contention is managed.
+            // For larger num_outcomes, a different reduction is needed.
+            // If num_outcomes is small (e.g., <= 64), atomicAdd on shared mem is often fine.
+            // Otherwise, each thread maintains its own num_outcomes bins and then reduce them.
+            // Let's assume num_target_paulis is small enough that num_outcomes is manageable for atomicAdd.
+            if (outcome_bin_idx < num_outcomes) { // Should always be true
+                 atomicAdd(&s_prob_bins[outcome_bin_idx], mag_sq);
+            }
+        }
+    }
+    __syncthreads();
+
+    // Block leader (thread 0 in block) writes the block's sums to global memory
+    if (tid_in_block == 0) {
+        for (unsigned bin_k = 0; bin_k < num_outcomes; ++bin_k) {
+            d_outcome_probs_blocks[blockIdx.x * num_outcomes + bin_k] = s_prob_bins[bin_k];
+        }
+    }
+}
+
+// Kernel to reduce block-level sums of multi-Z outcome probabilities to slice totals.
+// d_block_outcome_probs: input from previous kernel, size: num_prev_blocks * num_outcomes
+// d_slice_total_outcome_probs: output, size: num_outcomes
+__global__ void reduce_multi_z_block_probs_to_slice_total_kernel(
+    const real_t* d_block_outcome_probs,
+    unsigned num_prev_blocks,
+    unsigned num_outcomes, // 2^k (number of Zs in product)
+    real_t* d_slice_total_outcome_probs) {
+
+    // Shared memory for reduction. Size: blockDim.x (if reducing one outcome bin per thread)
+    // or num_outcomes (if each thread sums for one outcome bin across blocks).
+    // Let's choose the latter: each thread in this kernel is responsible for one outcome bin.
+    // So, this kernel should be launched with num_outcomes threads (if num_outcomes <= max_block_size).
+    extern __shared__ real_t s_final_probs[]; // Size: num_outcomes (passed as shared mem size at launch)
+
+    unsigned int outcome_idx_this_thread = threadIdx.x + blockIdx.x * blockDim.x; // This thread handles this outcome_idx
+
+    if (outcome_idx_this_thread < num_outcomes) {
+        real_t my_sum_for_this_outcome = 0.0;
+        // Sum probabilities for outcome_idx_this_thread across all blocks from previous kernel
+        for (unsigned block_i = 0; block_i < num_prev_blocks; ++block_i) {
+            my_sum_for_this_outcome += d_block_outcome_probs[block_i * num_outcomes + outcome_idx_this_thread];
+        }
+        s_final_probs[outcome_idx_this_thread] = my_sum_for_this_outcome; // Storing in shared, though not strictly needed if 1 block
+                                                                    // and writing directly to global.
+                                                                    // If launched with 1 block, num_outcomes threads:
+        d_slice_total_outcome_probs[outcome_idx_this_thread] = my_sum_for_this_outcome;
+    }
+    // If launched with multiple blocks, a further reduction of s_final_probs would be needed.
+    // For now, assume this kernel is launched with 1 block and num_outcomes threads.
+    // The C++ host code will need to ensure this launch configuration.
+}

--- a/rocquantum/src/rocqCompiler/MLIRCompiler.cpp
+++ b/rocquantum/src/rocqCompiler/MLIRCompiler.cpp
@@ -1,0 +1,131 @@
+#include "rocquantum/Compiler/MLIRCompiler.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Verifier.h"
+#include "llvm/Support/raw_ostream.h" // For dumping to string
+#include <string>
+
+namespace rocquantum {
+namespace compiler {
+
+MLIRCompiler::MLIRCompiler() {
+    context_ = std::make_unique<mlir::MLIRContext>();
+    // Load our custom Quantum dialect and any other dialects needed (e.g., func)
+    if (context_) {
+        context_->getOrLoadDialect<quantum::QuantumDialect>();
+        context_->getOrLoadDialect<mlir::func::FuncDialect>(); // Standard dialect for functions
+        // Add other dialects like arith, scf if they will be used directly
+    } else {
+        throw std::runtime_error("Failed to create MLIRContext.");
+    }
+}
+
+MLIRCompiler::~MLIRCompiler() {
+    // module_ and context_ will be cleaned up by their smart pointers.
+}
+
+bool MLIRCompiler::initializeModule(const std::string& moduleName) {
+    if (!context_) return false;
+
+    // Create a new ModuleOp.
+    // The OpBuilder is used to insert operations into the MLIR IR.
+    // We'll set the insertion point to the context to create a top-level ModuleOp.
+    mlir::OpBuilder builder(context_.get());
+    module_ = builder.create<mlir::ModuleOp>(builder.getUnknownLoc(), llvm::StringRef(moduleName));
+
+    return static_cast<bool>(module_); // Check if module creation was successful
+}
+
+void MLIRCompiler::dumpModule() const {
+    if (module_) {
+        module_->dump();
+    } else {
+        llvm::errs() << "MLIRCompiler: No module to dump.\n";
+    }
+}
+
+std::string MLIRCompiler::getModuleString() const {
+    if (!module_) {
+        return "MLIRCompiler: No module to get string from.";
+    }
+    std::string moduleStr;
+    llvm::raw_string_ostream ss(moduleStr);
+    module_->print(ss);
+    return ss.str();
+}
+
+mlir::MLIRContext* MLIRCompiler::getContext() {
+    return context_.get();
+}
+
+mlir::ModuleOp MLIRCompiler::getModule() const {
+    if (!module_) {
+        // This case should ideally not be hit if initializeModule was called and succeeded.
+        // Consider throwing or returning an empty ModuleOp if that's more appropriate.
+        return nullptr;
+    }
+    return *module_;
+}
+
+bool MLIRCompiler::loadModuleFromString(const std::string& mlirString) {
+    if (!context_) {
+        llvm::errs() << "MLIRContext not initialized, cannot parse module string.\n";
+        return false;
+    }
+
+    // Use MLIR's parser to parse the string.
+    // The mlir::parseSourceString function can be used here.
+    // It requires a SourceMgr and can populate an existing ModuleOp or create a new one.
+    // For simplicity, let's try to re-initialize module_ with the parsed content.
+
+    // llvm::SourceMgr sourceMgr;
+    // sourceMgr.AddNewSourceBuffer(llvm::MemoryBuffer::getMemBuffer(mlirString), llvm::SMLoc());
+
+    // Create a new module from the string.
+    // This will replace the existing module_ if any.
+    module_ = mlir::parseSourceString<mlir::ModuleOp>(mlirString, context_.get());
+
+    if (!module_) {
+        llvm::errs() << "Failed to parse MLIR string into a ModuleOp.\n";
+        return false;
+    }
+
+    // Optionally, verify the newly parsed module.
+    if (mlir::failed(mlir::verify(module_.get()))) {
+        llvm::errs() << "Parsed MLIR module failed verification.\n";
+        // module_->dump(); // Dump the problematic module
+        // module_ = nullptr; // Invalidate module if verification fails
+        // return false; // Strict: fail on verification error
+    }
+    // For now, let's be lenient on verification if parsing succeeded.
+
+    return true;
+}
+
+mlir::func::FuncOp MLIRCompiler::createFunction(const std::string& funcName,
+                                                mlir::TypeRange argTypes,
+                                                mlir::TypeRange resultTypes) {
+    if (!module_ || !context_) {
+        llvm::errs() << "Module or MLIRContext not initialized. Cannot create function.\n";
+        return nullptr; // Return an empty FuncOp
+    }
+
+    mlir::OpBuilder builder(module_->getBodyRegion()); // Builder to insert into module's body
+    auto functionType = mlir::FunctionType::get(context_.get(), argTypes, resultTypes);
+
+    // Create the function, but don't define its body yet.
+    // The location can be file/line info if available, otherwise UnknownLoc.
+    auto funcOp = builder.create<mlir::func::FuncOp>(builder.getUnknownLoc(), funcName, functionType);
+
+    // To define the function body, create a block and set the builder's insertion point.
+    // mlir::Block *entryBlock = funcOp.addEntryBlock();
+    // builder.setInsertionPointToStart(entryBlock);
+    // Now ops can be added to the function body using the builder.
+    // For now, this function just creates the FuncOp declaration.
+    // Callers will get the builder and add blocks/ops.
+
+    return funcOp;
+}
+
+
+} // namespace compiler
+} // namespace rocquantum


### PR DESCRIPTION
…ateVec TODOs

This commit includes the following completed work:

- Enhanced `rocqHybrid` `get_expval`:
  - Added C-API functions to `hipStateVec` (rocsvGetExpectationValueSinglePauliX/Y/Z, rocsvGetExpectationValuePauliProductZ, rocsvApplySdg) and kernels for <X_k>, <Y_k>, <Z_k> and <Z_i Z_j ...> calculations.
  - Updated Python bindings and `rocq.get_expval` to use these.
  - VQE example updated with a more complex Hamiltonian.

- MLIR Compiler Integration (Initial Scaffolding):
  - Created C++ files for `QuantumDialect` (QuantumDialect.h/cpp, QuantumOps.td, placeholder .inc files).
  - Implemented `MLIRCompiler` class (MLIRCompiler.h/cpp) to manage MLIRContext, ModuleOp, and support creating a module by parsing an MLIR string.
  - Added Python bindings for `MLIRCompiler`.
  - Updated `@rocq.kernel` in `api.py` for basic Python AST parsing to generate a string representation of MLIR.
  - `rocq.build()` now uses `MLIRCompiler` to parse this string into a `ModuleOp`.
  - `QuantumProgram` holds the `MLIRCompiler` instance.

- `hipTensorNet` Enhancements:
  - Improved `parse_simple_einsum_spec` in `rocTensorUtil.cpp` for multi-character labels and implicit output.

- `hipStateVec` TODOs Addressed:
  - Added API for managing a reusable pinned host buffer.
  - Added clarifying comments to multi-GPU functions regarding non-local qubit operations.

Work on transitioning from MLIR string generation to direct C++ Op construction was attempted but incomplete due to repeated errors in applying file diffs for `MLIRCompiler.h`. The goal was to add methods like `createFunction` and `addGenericGateOp` to `MLIRCompiler` and call them from Python.