### PR TITLE
Add backend target registry metadata and capability filtering APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ To access third-party backends, you must configure your credentials using enviro
 *   **For Pasqal & Infleqtion:**
     Set `PASQAL_API_KEY` and `SUPERSTAQ_API_KEY` respectively.
 
+## Target Registry and Capability Filtering
+
+`rocquantum.core` now includes a target-registry metadata layer inspired by CUDA-Q style target/capability discovery.
+
+```python
+from rocquantum.core import list_targets, require_target_capability
+
+sampling_targets = list_targets({"sampling"})
+require_target_capability("ionq", "job_lifecycle")
+```
+
+This allows applications to select execution targets based on capabilities (e.g., sampling, job lifecycle management) instead of hard-coding provider names.
+
 ## CLI Usage
 
 A simple Command-Line Interface is provided for quick demonstrations. It runs a standard Bell State circuit on the specified backend.

--- a/rocquantum/core.py
+++ b/rocquantum/core.py
@@ -6,27 +6,57 @@ in the rocQuantum framework.
 """
 
 import importlib
-from typing import Dict, Type, Optional
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional, Set, Type
 
 from .backends.base import RocqBackend
 
-_AVAILABLE_BACKENDS: Dict[str, str] = {
+@dataclass(frozen=True)
+class BackendSpec:
+    """Metadata that drives target selection and capability checks."""
+
+    import_path: str
+    backend_type: str
+    capabilities: Set[str] = field(default_factory=set)
+
+
+_AVAILABLE_BACKENDS: Dict[str, BackendSpec] = {
     # --- Implemented Backends ---
-    "ionq": "rocquantum.backends.ionq.IonQBackend",
-    "infleqtion": "rocquantum.backends.infleqtion.InfleqtionBackend",
-    "pasqal": "rocquantum.backends.pasqal.PasqalBackend",
-    "quantinuum": "rocquantum.backends.quantinuum.QuantinuumBackend",
-    "qristal": "rocquantum.backends.qristal.QuantumBrillianceBackend",
+    "ionq": BackendSpec(
+        import_path="rocquantum.backends.ionq.IonQBackend",
+        backend_type="remote_api",
+        capabilities={"sampling", "job_lifecycle", "qasm_submission"},
+    ),
+    "infleqtion": BackendSpec(
+        import_path="rocquantum.backends.infleqtion.InfleqtionBackend",
+        backend_type="remote_api",
+        capabilities={"sampling", "job_lifecycle", "qasm_submission"},
+    ),
+    "pasqal": BackendSpec(
+        import_path="rocquantum.backends.pasqal.PasqalBackend",
+        backend_type="remote_api",
+        capabilities={"sampling", "job_lifecycle", "qasm_submission"},
+    ),
+    "quantinuum": BackendSpec(
+        import_path="rocquantum.backends.quantinuum.QuantinuumBackend",
+        backend_type="remote_api",
+        capabilities={"sampling", "job_lifecycle", "qasm_submission"},
+    ),
+    "qristal": BackendSpec(
+        import_path="rocquantum.backends.qristal.QuantumBrillianceBackend",
+        backend_type="local_sdk",
+        capabilities={"sampling", "qasm_submission"},
+    ),
 
     # --- Skeleton Backends ---
-    "iqm": "rocquantum.backends.iqm.IQMBackend",
-    "rigetti": "rocquantum.backends.rigetti.RigettiBackend",
-    "xanadu": "rocquantum.backends.xanadu.XanaduBackend",
-    "quera": "rocquantum.backends.quera.QuEraBackend",
-    "orca": "rocquantum.backends.orca.OrcaBackend",
-    "seeqc": "rocquantum.backends.seeqc.SeeqcBackend",
-    "quantum_machines": "rocquantum.backends.quantum_machines.QuantumMachinesBackend",
-    "alice_bob": "rocquantum.backends.alice_bob.AliceBobBackend",
+    "iqm": BackendSpec("rocquantum.backends.iqm.IQMBackend", "skeleton", set()),
+    "rigetti": BackendSpec("rocquantum.backends.rigetti.RigettiBackend", "cloud_intermediary", {"sampling", "job_lifecycle", "qasm_submission"}),
+    "xanadu": BackendSpec("rocquantum.backends.xanadu.XanaduBackend", "skeleton", set()),
+    "quera": BackendSpec("rocquantum.backends.quera.QuEraBackend", "skeleton", set()),
+    "orca": BackendSpec("rocquantum.backends.orca.OrcaBackend", "skeleton", set()),
+    "seeqc": BackendSpec("rocquantum.backends.seeqc.SeeqcBackend", "skeleton", set()),
+    "quantum_machines": BackendSpec("rocquantum.backends.quantum_machines.QuantumMachinesBackend", "skeleton", set()),
+    "alice_bob": BackendSpec("rocquantum.backends.alice_bob.AliceBobBackend", "skeleton", set()),
 }
 
 _ACTIVE_BACKEND: Optional[RocqBackend] = None
@@ -37,7 +67,7 @@ def set_target(name: str, **kwargs) -> None:
     if name not in _AVAILABLE_BACKENDS:
         raise ValueError(f"Backend '{name}' not recognized. Available: {list(_AVAILABLE_BACKENDS.keys())}")
     
-    import_path = _AVAILABLE_BACKENDS[name]
+    import_path = _AVAILABLE_BACKENDS[name].import_path
     try:
         module_path, class_name = import_path.rsplit(".", 1)
         module = importlib.import_module(module_path)
@@ -48,6 +78,42 @@ def set_target(name: str, **kwargs) -> None:
     instance = backend_class(**kwargs)
     instance.authenticate()
     _ACTIVE_BACKEND = instance
+
+
+def get_target_spec(name: str) -> BackendSpec:
+    """Returns static metadata for a backend target."""
+    if name not in _AVAILABLE_BACKENDS:
+        raise ValueError(f"Backend '{name}' not recognized. Available: {list(_AVAILABLE_BACKENDS.keys())}")
+    return _AVAILABLE_BACKENDS[name]
+
+
+def list_targets(required_capabilities: Optional[Iterable[str]] = None) -> Dict[str, BackendSpec]:
+    """
+    Lists available targets, optionally filtered by required capabilities.
+
+    Examples:
+        list_targets()  # all configured backends
+        list_targets({"sampling", "job_lifecycle"})
+    """
+    if required_capabilities is None:
+        return dict(_AVAILABLE_BACKENDS)
+
+    required = set(required_capabilities)
+    return {
+        name: spec
+        for name, spec in _AVAILABLE_BACKENDS.items()
+        if required.issubset(spec.capabilities)
+    }
+
+
+def require_target_capability(name: str, capability: str) -> None:
+    """Validates that a target advertises a given capability before use."""
+    spec = get_target_spec(name)
+    if capability not in spec.capabilities:
+        raise RuntimeError(
+            f"Backend '{name}' does not advertise capability '{capability}'. "
+            f"Available capabilities: {sorted(spec.capabilities)}"
+        )
 
 def get_active_backend() -> RocqBackend:
     """Retrieves the currently active backend instance."""

--- a/tests/test_target_registry.py
+++ b/tests/test_target_registry.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+
+from rocquantum.core import (
+    BackendSpec,
+    get_target_spec,
+    list_targets,
+    require_target_capability,
+)
+
+
+class TestTargetRegistry(unittest.TestCase):
+    def test_get_target_spec_has_metadata(self):
+        spec = get_target_spec("ionq")
+        self.assertIsInstance(spec, BackendSpec)
+        self.assertEqual(spec.backend_type, "remote_api")
+        self.assertIn("sampling", spec.capabilities)
+
+    def test_list_targets_by_capability(self):
+        filtered = list_targets({"job_lifecycle"})
+        self.assertIn("ionq", filtered)
+        self.assertNotIn("qristal", filtered)
+
+    def test_require_target_capability(self):
+        require_target_capability("ionq", "sampling")
+
+        with self.assertRaises(RuntimeError):
+            require_target_capability("qristal", "job_lifecycle")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Make backend metadata first-class so callers can discover and select targets by advertised capabilities rather than by hard-coded names.
- Provide a lightweight capability model (e.g., `sampling`, `job_lifecycle`, `qasm_submission`) to enable future routing/validation logic and simpler integration tests.
- Improve ergonomics for multi-backend orchestration and pave the way for CUDA-Q style target/capability routing.

### Description

- Introduced a frozen `BackendSpec` dataclass and replaced the string map with `_AVAILABLE_BACKENDS: Dict[str, BackendSpec]` that records `import_path`, `backend_type`, and `capabilities` for each target.
- Updated `set_target()` to resolve backend classes from the registry and kept the runtime behavior (instantiation + `authenticate()`); added helper APIs: `get_target_spec()`, `list_targets(required_capabilities=None)`, and `require_target_capability(name, capability)` to query and validate targets by capability.
- Added a short usage example into `README.md` documenting `list_targets` / `require_target_capability` and added unit tests in `tests/test_target_registry.py` to assert metadata, filtering, and capability checks.

### Testing

- Ran the new unit test module with `python -m unittest tests/test_target_registry.py`, which executed the test set and passed (`Ran 3 tests — OK`).
- The changes are covered by the test that verifies `get_target_spec()` returns a `BackendSpec`, `list_targets()` filters by capability, and `require_target_capability()` raises when capability is missing.
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e87f47ca483319429b021ed02aa35)